### PR TITLE
Rename 'Today' to '24-Hour Forecast'

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -203,7 +203,7 @@
 
             <div class="all-24">
                 <div class="h1">
-                    <p class="today_Text">Today</p>
+                    <p class="today_Text">24-Hour Forecast</p>
                     <p class="date_Text_top" id="date_text_top">Mar, 19</p>
                 </div>
                 <div class="forecast" id="forecast">


### PR DESCRIPTION
I think it could be a bit confusing without this change, and also there is the 8-Day Forecast so I orientated at that.