### PR TITLE
compute daily weather summary from daylight hours only

### DIFF
--- a/app/src/main/java/com/pranshulgg/weathermaster/data/local/mapper/weather/OpenMeteoMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weathermaster/data/local/mapper/weather/OpenMeteoMapper.kt
@@ -1,10 +1,13 @@
 package com.pranshulgg.weathermaster.data.local.mapper.weather
 
+import com.pranshulgg.weathermaster.core.model.astro.SunTimings
 import com.pranshulgg.weathermaster.core.model.domain.Location
 import com.pranshulgg.weathermaster.core.model.domain.Weather
 import com.pranshulgg.weathermaster.core.model.domain.WeatherCurrent
 import com.pranshulgg.weathermaster.core.model.domain.WeatherDaily
 import com.pranshulgg.weathermaster.core.model.domain.WeatherHourly
+import com.pranshulgg.weathermaster.core.model.weather.WeatherConditions
+import com.pranshulgg.weathermaster.core.network.openmeteo.OpenMeteoHourlyDataDto
 import com.pranshulgg.weathermaster.core.network.openmeteo.OpenMeteoWeatherDto
 import com.pranshulgg.weathermaster.core.network.openmeteo.openMeteoWeatherCode
 import com.pranshulgg.weathermaster.core.utils.formatters.toMilliseconds
@@ -81,6 +84,44 @@ fun List<WeatherDaily>.toDailyWeatherEntity(
         )
     }
 
+private fun daylightHourIndices(
+    dayIndex: Int,
+    hourly: OpenMeteoHourlyDataDto,
+    sunTimings: List<SunTimings>,
+): List<Int>? {
+    val sunrise = sunTimings[dayIndex].sunrise ?: return null
+    val sunset = sunTimings[dayIndex].sunset ?: return null
+    val indices = hourly.time.indices.filter { idx ->
+        hourly.time[idx].toMilliseconds() in sunrise..sunset
+    }
+    return indices.ifEmpty { null }
+}
+
+private fun daytimeWeatherCondition(
+    dayIndex: Int,
+    hourly: OpenMeteoHourlyDataDto,
+    sunTimings: List<SunTimings>,
+    fallback: WeatherConditions,
+): WeatherConditions {
+    val indices = daylightHourIndices(dayIndex, hourly, sunTimings) ?: return fallback
+    return indices
+        .map { openMeteoWeatherCode(hourly.weatherCode[it]) }
+        .groupingBy { it }
+        .eachCount()
+        .maxByOrNull { it.value }
+        ?.key ?: fallback
+}
+
+private fun daytimePrecipitationMax(
+    dayIndex: Int,
+    hourly: OpenMeteoHourlyDataDto,
+    sunTimings: List<SunTimings>,
+    fallback: Int,
+): Int {
+    val indices = daylightHourIndices(dayIndex, hourly, sunTimings) ?: return fallback
+    return indices.maxOf { hourly.precipitationProbability[it] }
+}
+
 @OptIn(ExperimentalUuidApi::class)
 fun OpenMeteoWeatherDto.toDomain(location: Location): Weather {
 
@@ -152,9 +193,19 @@ fun OpenMeteoWeatherDto.toDomain(location: Location): Weather {
                 rainSum = daily.rainSum[it],
                 snowfallSum = daily.snowfallSum[it],
                 uvIndexMax = daily.uvIndexMax[it],
-                weatherCondition = openMeteoWeatherCode(daily.weatherCode[it]),
+                weatherCondition = daytimeWeatherCondition(
+                    dayIndex = it,
+                    hourly = hourly,
+                    sunTimings = sunTimings,
+                    fallback = openMeteoWeatherCode(daily.weatherCode[it]),
+                ),
                 time = daily.time[it].toMilliseconds(), // Open-Meteo returns in seconds
-                precipitationProbabilityMax = daily.precipitationProbabilityMax[it],
+                precipitationProbabilityMax = daytimePrecipitationMax(
+                    dayIndex = it,
+                    hourly = hourly,
+                    sunTimings = sunTimings,
+                    fallback = daily.precipitationProbabilityMax[it],
+                ),
                 sunrise = sunTimings[it].sunrise ?: -0L,
                 sunset = sunTimings[it].sunset ?: -0L,
                 moonrise = moonTimings[it].moonrise ?: -0L,


### PR DESCRIPTION
Addresses #823.

## Summary

Open-Meteo aggregates `daily.weather_code` and `precipitation_probability_max` over the full 24h day, so a clear day with light overnight rain shows up as "rainy" in the daily forecast. This computes both fields from hourly values between sunrise and sunset instead:

- `weatherCondition`: mode (most frequent condition) among daylight hours
- `precipitationProbabilityMax`: max across daylight hours only

Falls back to the existing 24h aggregate when the daylight window is unavailable (polar day/night, or any case where `sunTimings.sunrise/sunset` is null).

All the logic lives in three small private helpers added at the top of `OpenMeteoMapper.kt`. The existing `daily` block in `toDomain()` is unchanged except for the two field assignments that now call the helpers.

## Caveat / open question

In #823 I proposed adding this as a **settings toggle** (between `24h aggregate` and `Daytime weighted`). This PR doesn't add the toggle — it changes the default behavior directly.

I sent it this way as a **proof-of-concept** to validate that the algorithm works visually before committing time to settings UI scaffolding. Happy to refactor it into a toggle (with `24h aggregate` as the default for backward compatibility) if that's the direction you'd prefer. Or to drop it entirely if you'd rather take a different approach.

## Visual result

Tested locally on a Pixel 8 emulator (API 36.1) for Québec City, comparing the daily forecast before and after the change. The "Sun May 17" / "Mon May 18" days (sunny daytime with light overnight rain) flip from a rain icon to clear / partly-cloudy, matching what users would expect for daytime planning. Days with significant daylight rain (Tue/Wed in that forecast) keep their rain icon as expected.

## Dependency

Depends on #824 (missing `rainy_light_24px` drawable) — without that fix, `main` does not currently compile. #824 can be merged independently of this PR.

_Note: English isn't my first language, LLM-assisted phrasing. Happy to clarify anything that reads oddly._