### PR TITLE
Fix visibility graph overflow

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/blocks/screens/visibility/components/VisibilityHourlyCard.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/blocks/screens/visibility/components/VisibilityHourlyCard.kt
@@ -97,7 +97,7 @@ fun VisibilityHourlyCard(
                     val percentage = ((item.visibility!!.minus(visibilityMin))
                         .div((visibilityMax - visibilityMin))).times(100.0)
 
-                    val barHeight = max((percentage.div(100.0)).times(140.0), 5.0)
+                    val barHeight = max((percentage.div(100.0)).times(140.0), 5.0).coerceAtMost(140.0)
 
 
                     val visibilityKm =


### PR DESCRIPTION
## Summary

- cap visibility bars at the chart's fixed 140 dp track height
- preserve the existing minimum bar height and full displayed visibility value

## Testing

- `testDebugUnitTest`
- `assembleDebug`
- Android 16 install and cold-launch smoke test
- `lintDebug` analysis completed with only existing unrelated project errors

Fixes #976
