### PR TITLE
Localize AccuWeather Alerts and date/times

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/accu/AlertsAccuApi.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/accu/AlertsAccuApi.kt
@@ -20,7 +20,8 @@ interface AlertsAccuApi {
     @GET("alerts/v1/{locationKey}")
     suspend fun fetchAlerts(
         @Path("locationKey") locationKey: String,
-        @Query("details") details: Boolean = true
+        @Query("details") details: Boolean = true,
+        @Query("language") language: String
     ): Response<List<AlertsAccuJson>>
 
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/accu/AlertsAccuRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/accu/AlertsAccuRepository.kt
@@ -5,6 +5,7 @@ import com.pranshulgg.weather_master_app.core.model.domain.location.Location
 import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResult
 import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResultType
 import com.pranshulgg.weather_master_app.core.network.sources.weather.accu.AccuApi
+import com.pranshulgg.weather_master_app.core.utils.locale.getCurrentAppLocale
 import com.pranshulgg.weather_master_app.core.utils.weather.cache.shouldReturnAlertsCache
 import com.pranshulgg.weather_master_app.data.local.dao.alerts.AlertsDao
 import com.pranshulgg.weather_master_app.data.local.dao.location.LocationKeysDao
@@ -53,7 +54,7 @@ class AlertsAccuRepository @Inject constructor(
                         .body()?.key
                     ?: return@withContext AlertResult.Error(exception = AppException.Unknown())
 
-            val response = api.fetchAlerts(locationKey)
+            val response = api.fetchAlerts(locationKey, language = getCurrentAppLocale().language)
             val body = response.body()
                 ?: return@withContext AlertResult.Error(exception = AppException.Unknown())
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/formatters/DateTimeFormatters.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/formatters/DateTimeFormatters.kt
@@ -1,14 +1,22 @@
 package com.pranshulgg.weather_master_app.core.utils.formatters
 
 import android.content.Context
+import android.text.format.DateFormat
 import com.pranshulgg.weather_master_app.R
 import com.pranshulgg.weather_master_app.core.utils.locale.getCurrentAppLocale
 import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.zone.ZoneRulesException
 import java.util.concurrent.TimeUnit
-import java.time.ZoneId
-import java.time.ZonedDateTime
+
+/**
+ * Modify the date and/or time pattern to adapt to the current locale.
+ */
+fun getLocalizedPattern(pattern: String): String {
+    return DateFormat.getBestDateTimePattern(getCurrentAppLocale(), pattern)
+}
 
 fun to12HourTimeString(timeMilli: Long, zoneId: String, pattern: String = "ha"): String {
     val instant = Instant.ofEpochMilli(timeMilli)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/formatters/DateTimeFormatters.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/formatters/DateTimeFormatters.kt
@@ -45,11 +45,11 @@ fun toWeekdayString(timeMilli: Long, zoneId: String): String {
     return formatter.format(zonedDateTime)
 }
 
-fun toDateString(timeMilli: Long, zoneId: String, pattern: String = "dd MMMM"): String {
+fun toDateString(timeMilli: Long, zoneId: String, pattern: String = "ddMMMM"): String {
     val instant = Instant.ofEpochMilli(timeMilli)
     val zonedDateTime = instant.atZone(safeZoneId(zoneId))
-    val formatter = DateTimeFormatter.ofPattern(pattern, getCurrentAppLocale())
-
+    val formatter = DateTimeFormatter
+        .ofPattern(getLocalizedPattern(pattern), getCurrentAppLocale())
 
     return formatter.format(zonedDateTime)
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/formatters/DateTimeFormatters.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/formatters/DateTimeFormatters.kt
@@ -20,15 +20,17 @@ fun getLocalizedPattern(pattern: String): String {
 
 fun to12HourTimeString(timeMilli: Long, zoneId: String, pattern: String = "ha"): String {
     val instant = Instant.ofEpochMilli(timeMilli)
-    val formatter = DateTimeFormatter.ofPattern(pattern, getCurrentAppLocale())
+    val formatter = DateTimeFormatter
+        .ofPattern(getLocalizedPattern(pattern), getCurrentAppLocale())
         .withZone(safeZoneId(zoneId))
 
     return formatter.format(instant)
 }
 
-fun to24HourTimeString(timeMilli: Long, zoneId: String, pattern: String = "HH:mm"): String {
+fun to24HourTimeString(timeMilli: Long, zoneId: String, pattern: String = "Hm"): String {
     val instant = Instant.ofEpochMilli(timeMilli)
-    val formatter = DateTimeFormatter.ofPattern(pattern, getCurrentAppLocale())
+    val formatter = DateTimeFormatter
+        .ofPattern(getLocalizedPattern(pattern), getCurrentAppLocale())
         .withZone(safeZoneId(zoneId))
 
     return formatter.format(instant)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/alerts/sources/accu/AccuAlertsMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/alerts/sources/accu/AccuAlertsMapper.kt
@@ -9,7 +9,7 @@ import com.pranshulgg.weather_master_app.core.utils.extensions.DateTimeExtension
 fun AlertsAccuJson.toDomain(locationId: String): Alert {
     return Alert(
         locationId = locationId,
-        event = event.english,
+        event = event.localized.ifBlank { event.english },
         severity = getSeverity(alarmLevel),
         effective = area[0].epochStartTimeSeconds.secondsToMilliseconds(),
         expires = area[0].epochEndTimeSeconds.secondsToMilliseconds(),

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/alerts/components/AlertCard.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/alerts/components/AlertCard.kt
@@ -26,6 +26,7 @@ import com.pranshulgg.weather_master_app.core.prefs.AppPrefsState
 import com.pranshulgg.weather_master_app.core.ui.components.Gap
 import com.pranshulgg.weather_master_app.core.ui.components.Symbol
 import com.pranshulgg.weather_master_app.core.ui.theme.ShadowElevation
+import com.pranshulgg.weather_master_app.core.utils.formatters.getLocalizedPattern
 import com.pranshulgg.weather_master_app.core.utils.formatters.safeZoneId
 import java.time.Instant
 import java.time.format.DateTimeFormatter
@@ -33,7 +34,9 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun AlertCard(alert: Alert, prefs: AppPrefsState, zoneId: String, shape: Shape) {
-    val pattern = if (prefs.is24HrTimeFormat) "MMM dd, HH:mm" else "MMM dd, hh:mm a"
+    val pattern = getLocalizedPattern(
+        if (prefs.is24HrTimeFormat) "MMMddHmm" else "MMMddhmma"
+    )
 
     val formatter: (Long?) -> String? = {
         it?.let {

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/daily/ui/DailyForecastHeroHeader.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/daily/ui/DailyForecastHeroHeader.kt
@@ -1,6 +1,5 @@
 package com.pranshulgg.weather_master_app.feature.daily.ui
 
-import android.text.format.DateFormat.getBestDateTimePattern
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -21,7 +20,6 @@ import com.pranshulgg.weather_master_app.core.model.weather.toLabel
 import com.pranshulgg.weather_master_app.core.ui.components.Gap
 import com.pranshulgg.weather_master_app.core.ui.components.WeatherIconBox
 import com.pranshulgg.weather_master_app.core.utils.formatters.toDateString
-import com.pranshulgg.weather_master_app.core.utils.locale.getCurrentAppLocale
 import kotlin.math.roundToInt
 
 
@@ -32,12 +30,7 @@ fun DailyForecastHeroHeader(
     units: WeatherUnits
 ) {
 
-    val date = toDateString(
-        daily.time, location.timezone, getBestDateTimePattern(
-            getCurrentAppLocale(),
-            "MMMMdd"
-        )
-    )
+    val date = toDateString(daily.time, location.timezone)
     val context = LocalContext.current
 
     val maxTemp =

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/ui/AlertsSection.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/ui/AlertsSection.kt
@@ -21,6 +21,7 @@ import com.pranshulgg.weather_master_app.core.prefs.AppPrefsState
 import com.pranshulgg.weather_master_app.core.ui.components.SettingSection
 import com.pranshulgg.weather_master_app.core.ui.components.Symbol
 import com.pranshulgg.weather_master_app.core.ui.theme.ShadowElevation
+import com.pranshulgg.weather_master_app.core.utils.formatters.getLocalizedPattern
 import com.pranshulgg.weather_master_app.core.utils.formatters.safeZoneId
 import java.time.Instant
 import java.time.ZoneId
@@ -34,9 +35,9 @@ fun AlertsSection(
     onAlertClick: () -> Unit
 ) {
 
-    val pattern = if (prefs.is24HrTimeFormat) "MMM dd, HH:mm" else "MMM dd, hh:mm a"
-
-
+    val pattern = getLocalizedPattern(
+        if (prefs.is24HrTimeFormat) "MMMddHmm" else "MMMddhmma"
+    )
     val formatter: (Long) -> String = {
         val formatter = DateTimeFormatter.ofPattern(pattern)
         val instant = Instant.ofEpochMilli(it)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/ui/DailyCard.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/ui/DailyCard.kt
@@ -1,10 +1,8 @@
 package com.pranshulgg.weather_master_app.feature.shared.ui
 
-import android.text.format.DateFormat.getBestDateTimePattern
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -29,14 +27,10 @@ import com.pranshulgg.weather_master_app.core.ui.components.Gap
 import com.pranshulgg.weather_master_app.core.ui.components.WeatherIconBox
 import com.pranshulgg.weather_master_app.core.ui.navigation.NavRoutes
 import com.pranshulgg.weather_master_app.core.ui.theme.ShadowElevation
-import com.pranshulgg.weather_master_app.core.utils.formatters.safeZoneId
 import com.pranshulgg.weather_master_app.core.utils.formatters.toDateString
 import com.pranshulgg.weather_master_app.core.utils.formatters.toWeekdayString
-import com.pranshulgg.weather_master_app.core.utils.locale.getCurrentAppLocale
 import com.pranshulgg.weather_master_app.core.utils.weather.cache.isWeatherDailyDomainSafe
 import com.pranshulgg.weather_master_app.feature.shared.components.CardsHeader
-import java.time.Instant
-import java.time.format.DateTimeFormatter
 import kotlin.math.roundToInt
 
 
@@ -91,10 +85,7 @@ fun DailyCard(weather: Weather, units: WeatherUnits, navController: NavControlle
                         date = toDateString(
                             item.time,
                             weather.location.timezone,
-                            pattern = getBestDateTimePattern(
-                                getCurrentAppLocale(),
-                                "Mdd"
-                            )
+                            pattern = "Mdd"
                         )
                     )
 


### PR DESCRIPTION
Hi, I made some fixes to get better localizations:
- use the localized description of AccuWeather alerts instead of the default english description (this part annoyed me recently, because we are under constant extreme heat alerts in France and the warning was not in the same language as the rest of the app)
- use `DateFormat.getBestDateTimePattern` to apply the correct pattern on date-time in alerts depending on the current selected locale: eg: "_august 12, 12:12_" in english but "_12 août, 12:12_" in french (and not "_août 12, 12:12_")
- also apply the `getBestDateTimePattern` fix to the other date/time formatters utils