### PR TITLE
Update device location on app-open and fix a leftover single-provider gate

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/provider/devicelocation/DeviceLocationProvider.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/provider/devicelocation/DeviceLocationProvider.kt
@@ -33,13 +33,6 @@ class GetDeviceLocation {
     private var timeoutRunnable: Runnable? = null
 
     private val timeoutMillis = 20_000L
-    private fun getProvider(lm: LocationManager): String {
-        return when {
-            lm.allProviders.contains(LocationManager.NETWORK_PROVIDER) -> LocationManager.NETWORK_PROVIDER
-            lm.allProviders.contains(LocationManager.GPS_PROVIDER) -> LocationManager.GPS_PROVIDER
-            else -> LocationManager.PASSIVE_PROVIDER
-        }
-    }
 
     fun getDeviceLocation(
         context: Context,
@@ -71,22 +64,13 @@ class GetDeviceLocation {
 
         locationManager = lm
 
-        val provider = getProvider(lm)
-
-        if (!lm.isProviderEnabled(provider)) {
-            onResult(DeviceLocation(null, null))
-            return
-        }
-
-
-        getLocation(onLocation = { onResult(it) }, lm, provider, onTimeout)
+        getLocation(onLocation = { onResult(it) }, lm, onTimeout)
     }
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
     private fun getLocation(
         onLocation: (DeviceLocation) -> Unit,
         lm: LocationManager,
-        provider: String,
         onTimeout: () -> Unit
     ) {
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/repository/LocationsRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/repository/LocationsRepository.kt
@@ -131,7 +131,12 @@ class LocationsRepository @Inject constructor(
 
     val getDeviceLocation = GetDeviceLocation()
 
-    suspend fun updateDeviceLocationPosition() {
+    /**
+     * Refreshes the saved device-location entry if the device has moved far enough.
+     * Returns true if the location was actually updated (so callers know to force
+     * a fresh weather fetch instead of trusting a now-stale cache).
+     */
+    suspend fun updateDeviceLocationPosition(): Boolean {
 
         val location = suspendCancellableCoroutine { cont ->
             getDeviceLocation.getDeviceLocation(
@@ -144,8 +149,8 @@ class LocationsRepository @Inject constructor(
         }
 
 
-        val newLat = location.latitude ?: return
-        val newLon = location.longitude ?: return
+        val newLat = location.latitude ?: return false
+        val newLon = location.longitude ?: return false
 
         val currentLocation = dao.getDeviceLocation()
 
@@ -163,7 +168,7 @@ class LocationsRepository @Inject constructor(
         val distanceInMeters = results[0]
         // Only update the location if needed
         if (distanceInMeters < LOCATION_UPDATE_THRESHOLD_METERS) {
-            return
+            return false
         }
         val address = try {
             nominatimRepository.getAddress(
@@ -184,6 +189,8 @@ class LocationsRepository @Inject constructor(
             ?: "",
             ZoneId.systemDefault().id
         )
+
+        return true
     }
 
     suspend fun saveDeviceLocation() {

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/data/WeatherAutoRefreshForeground.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/data/WeatherAutoRefreshForeground.kt
@@ -25,6 +25,12 @@ fun WeatherAutoRefreshForeground(
                             location = it,
                             source = it.source
                         )
+                        // Cache-respecting; only forces a real refetch if the
+                        // device location actually moved since last time.
+                        weatherViewModel.getWeather(
+                            location = it,
+                            source = it.source
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/data/WeatherAutoRefreshForeground.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/data/WeatherAutoRefreshForeground.kt
@@ -25,12 +25,21 @@ fun WeatherAutoRefreshForeground(
                             location = it,
                             source = it.source
                         )
+                        // Guarded on isInitialized so this only fires on a genuine
+                        // resume-from-background, not the initial cold-start load
+                        // (setActiveLocation() already covers that one, and this
+                        // DisposableEffect re-subscribes - and Android replays a
+                        // synthetic ON_START on subscribe when the lifecycle is
+                        // already started - the moment `location` first becomes
+                        // non-null, which would otherwise double-fire here too).
                         // Cache-respecting; only forces a real refetch if the
                         // device location actually moved since last time.
-                        weatherViewModel.getWeather(
-                            location = it,
-                            source = it.source
-                        )
+                        if (weatherViewModel.uiState.value.isInitialized) {
+                            weatherViewModel.getWeather(
+                                location = it,
+                                source = it.source
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/data/WeatherAutoRefreshForeground.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/data/WeatherAutoRefreshForeground.kt
@@ -25,15 +25,9 @@ fun WeatherAutoRefreshForeground(
                             location = it,
                             source = it.source
                         )
-                        // Guarded on isInitialized so this only fires on a genuine
-                        // resume-from-background, not the initial cold-start load
-                        // (setActiveLocation() already covers that one, and this
-                        // DisposableEffect re-subscribes - and Android replays a
-                        // synthetic ON_START on subscribe when the lifecycle is
-                        // already started - the moment `location` first becomes
-                        // non-null, which would otherwise double-fire here too).
-                        // Cache-respecting; only forces a real refetch if the
-                        // device location actually moved since last time.
+                        // isInitialized guard avoids duplicating setActiveLocation()'s
+                        // cold-start fetch (Android replays ON_START on resubscribe,
+                        // which happens the moment `location` first becomes non-null).
                         if (weatherViewModel.uiState.value.isInitialized) {
                             weatherViewModel.getWeather(
                                 location = it,

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
@@ -130,21 +130,38 @@ class WeatherViewModel @Inject constructor(
 
         weatherJob = viewModelScope.launch {
 
-            if (location.isDeviceLocation && isManualRefresh) {
-                handleDeviceLocation()
+            var effectiveLocation = location
+            var effectiveForceRefresh = isForceRefresh
+            var effectiveForceRefreshForAirQuality = isForceRefreshForAirQuality
+            var effectiveForceRefreshForAlerts = isForceRefreshForAlerts
+
+            // Checked regardless of isManualRefresh so it also runs on app-open/auto-refresh,
+            // not just pull-to-refresh. If the device actually moved, force a real fetch for
+            // the new coordinates instead of trusting a cache keyed to the old ones (note:
+            // isForceRefresh bypasses the cache unconditionally, unlike isManualRefresh, which
+            // only relaxes the cache TTL and would still be blocked by the 15-min throttle).
+            if (location.isDeviceLocation) {
+                val positionChanged = handleDeviceLocation()
+                if (positionChanged) {
+                    effectiveLocation = locationsRepo.getLocationForId(location.id)
+                    effectiveForceRefresh = true
+                    effectiveForceRefreshForAirQuality = true
+                    effectiveForceRefreshForAlerts = true
+                    _uiState.value = _uiState.value.copy(activeLocation = effectiveLocation)
+                }
             }
 
             // Run separately
             if (!_uiState.value.isError) {
                 launch {
-                    handleAirQuality(location, isManualRefresh, isForceRefreshForAirQuality)
+                    handleAirQuality(effectiveLocation, isManualRefresh, effectiveForceRefreshForAirQuality)
                 }
                 launch {
-                    handleAlerts(location, isManualRefresh, isForceRefreshForAlerts)
+                    handleAlerts(effectiveLocation, isManualRefresh, effectiveForceRefreshForAlerts)
                 }
             }
 
-            handleWeatherData(source, location, isManualRefresh, isForceRefresh)
+            handleWeatherData(source, effectiveLocation, isManualRefresh, effectiveForceRefresh)
 
             val elapsed = System.currentTimeMillis() - startTime
             val minLoadingTime = 1000L // 1s
@@ -276,8 +293,8 @@ class WeatherViewModel @Inject constructor(
     }
 
 
-    private suspend fun handleDeviceLocation() {
-        locationsRepo.updateDeviceLocationPosition()
+    private suspend fun handleDeviceLocation(): Boolean {
+        return locationsRepo.updateDeviceLocationPosition()
     }
 
     private suspend fun handleWeatherData(


### PR DESCRIPTION
Closes #1035.

While digging into #1035 ("Set location upon app-open"), found two related device-location bugs — one is the reported issue, the other is a gap left over from the #938 fix that's easy to hit on the same code path.

## #1035: device location never updates on app-open

`WeatherViewModel.getWeather()` only checked/refreshed the device location when `isManualRefresh` was true — i.e. only on pull-to-refresh. It never ran on app cold-start, app-resume from background, or the 45-min auto-refresh timer, so if you traveled and just reopened the app without manually refreshing, it stayed on the old city indefinitely.

Fix: decoupled the device-location check from `isManualRefresh` so it always runs for a device-location entry, regardless of how the fetch was triggered. When it detects the device has actually moved, it forces a real refetch via `isForceRefresh` (not `isManualRefresh` — that flag only relaxes the cache TTL and would still get blocked by the existing 15-minute manual-refresh throttle, which doesn't distinguish "just refreshed" from "moved cities"). Also wired an immediate check into `WeatherAutoRefreshForeground`'s existing `ON_START` lifecycle observer, since that's the one hook that already fires on every foreground-resume, not just cold start — previously it only used `ON_START` to (re)schedule the 45-min timer.

## Leftover single-provider gate from #938

`DeviceLocationProvider.getDeviceLocation()` still gated on the old single-provider selection (`getProvider()`, preferring `NETWORK_PROVIDER`) before ever reaching the dual-provider live-request logic the #938 fix added to `getLocation()`. If that one preferred provider happened to be present-but-disabled (e.g. system location mode set to "Device only", or no GMS/network-location backend on the device), it failed instantly with "Current location not found" — without ever trying GPS, even though GPS was fully available. Removed the stale gate; `getLocation()`'s own dual-provider logic already handles provider selection correctly.

## Testing performed

Both fixes tested end-to-end on a real emulator (mocked GPS via `cmd location providers set-test-provider-location`, not just `emu geo fix`, since the latter doesn't reliably update the location cache without an active listener):

- Reproduced #1035 cleanly: added a location via the real "Enable Location" flow, backgrounded the app, moved the mock location >1000m away, reopened the app without touching refresh — location stayed stale on the old city.
- Confirmed the fix resolves it: same steps, but on reopen the location name, coordinates, and weather data all update automatically, no manual refresh needed.
- Confirmed manual pull-to-refresh still works correctly (control case, unaffected by this change).
- Confirmed the provider-gate fix separately: on a config with `NETWORK_PROVIDER` disabled but GPS enabled and holding a valid cached fix, "Enable Location" now succeeds instead of instantly failing.