### PR TITLE
Add JMA (Japan) as a weather forecast source

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/di/network/ApiModule.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/di/network/ApiModule.kt
@@ -14,6 +14,7 @@ import com.pranshulgg.weather_master_app.core.network.sources.weather.aemet.Aeme
 import com.pranshulgg.weather_master_app.core.network.sources.weather.bmkg.BmkgApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.china.ChinaApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.cwa.CwaApi
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.JmaApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.dwd.DwdApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.eccc.EcccApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.fmi.FmiApi
@@ -154,4 +155,8 @@ object ApiModule {
     @Provides
     @Singleton
     fun provideCwaApi(): CwaApi = CwaApi.create()
+
+    @Provides
+    @Singleton
+    fun provideJmaApi(): JmaApi = JmaApi.create()
 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/WeatherRepositoryModule.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/WeatherRepositoryModule.kt
@@ -242,6 +242,7 @@ object WeatherRepositoryModule {
         dao: LocationsDao,
         weatherDao: WeatherDao,
         api: JmaApi,
-        locationKeysDao: LocationKeysDao
-    ): JmaRepository = JmaRepository(dao, weatherDao, api, locationKeysDao)
+        locationKeysDao: LocationKeysDao,
+        alertsDao: AlertsDao
+    ): JmaRepository = JmaRepository(dao, weatherDao, api, locationKeysDao, alertsDao)
 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/WeatherRepositoryModule.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/WeatherRepositoryModule.kt
@@ -21,6 +21,8 @@ import com.pranshulgg.weather_master_app.core.network.sources.weather.gismeteo.G
 import com.pranshulgg.weather_master_app.core.network.sources.weather.gismeteo.GismeteoRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.imd.ImdApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.imd.ImdRepository
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.JmaApi
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.JmaRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.ipma.IpmaApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.ipma.IpmaRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.meteoam.MeteoamApi
@@ -233,4 +235,13 @@ object WeatherRepositoryModule {
         apiKeysDao: ApiKeysDao,
         locationKeysDao: LocationKeysDao
     ): CwaRepository = CwaRepository(dao, weatherDao, api, apiKeysDao, locationKeysDao)
+
+    @Provides
+    @Singleton
+    fun provideJmaRepository(
+        dao: LocationsDao,
+        weatherDao: WeatherDao,
+        api: JmaApi,
+        locationKeysDao: LocationKeysDao
+    ): JmaRepository = JmaRepository(dao, weatherDao, api, locationKeysDao)
 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
@@ -176,6 +176,13 @@ enum class Source(
         countryNameRes = R.string.country_taiwan,
         requiresUserApiKey = true,
         capabilities = setOf(Capability.WEATHER)
+    ),
+    JMA(
+        displayName = "JMA",
+        fullName = "Japan Meteorological Agency",
+        displayLink = "https://www.jma.go.jp/bosai/",
+        countryNameRes = R.string.country_japan,
+        capabilities = setOf(Capability.WEATHER)
     );
 
     // Sources that provide snow/rain as precipitation
@@ -187,6 +194,7 @@ enum class Source(
             BMKG -> false
             IMD -> false
             CWA -> false
+            JMA -> false
             else -> true
         }
     }
@@ -212,6 +220,7 @@ private val sourcesByCountry = buildMap {
     put("ES", listOf(Source.AEMET))
     put("IN", listOf(Source.IMD))
     put("TW", listOf(Source.CWA))
+    put("JP", listOf(Source.JMA))
 
 }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
@@ -182,7 +182,7 @@ enum class Source(
         fullName = "Japan Meteorological Agency",
         displayLink = "https://www.jma.go.jp/bosai/",
         countryNameRes = R.string.country_japan,
-        capabilities = setOf(Capability.WEATHER)
+        capabilities = setOf(Capability.WEATHER, Capability.ALERTS)
     );
 
     // Sources that provide snow/rain as precipitation

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaApi.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaApi.kt
@@ -1,0 +1,62 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma
+
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaAmedasCurrentJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaAmedasStationJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaAreaJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaForecastBlockJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaHourlyJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaWeekAreaEntryJson
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Path
+import java.util.concurrent.TimeUnit
+
+// All endpoints are free, public, no API key or auth of any kind - confirmed live for every
+// call this source makes.
+interface JmaApi {
+
+    @GET("common/const/area.json")
+    suspend fun getAreas(): JmaAreaJson
+
+    @GET("forecast/const/week_area.json")
+    suspend fun getWeekArea(): Map<String, List<JmaWeekAreaEntryJson>>
+
+    @GET("amedas/const/amedastable.json")
+    suspend fun getAmedasTable(): Map<String, JmaAmedasStationJson>
+
+    // officeCode = a class10 region's "parent" field. Returns [nearTermBlock, weeklyBlock].
+    @GET("forecast/data/forecast/{officeCode}.json")
+    suspend fun getForecast(@Path("officeCode") officeCode: String): List<JmaForecastBlockJson>
+
+    // class10Code = the resolved region code directly (real 3-hourly numeric data).
+    @GET("jmatile/data/wdist/VPFD/{class10Code}.json")
+    suspend fun getHourly(@Path("class10Code") class10Code: String): JmaHourlyJson
+
+    // dateHour must be "yyyyMMdd_HH" in JST.
+    @GET("amedas/data/point/{amedasId}/{dateHour}.json")
+    suspend fun getAmedasCurrent(
+        @Path("amedasId") amedasId: String,
+        @Path("dateHour") dateHour: String
+    ): Map<String, JmaAmedasCurrentJson>
+
+    companion object {
+        const val BASE_URL = "https://www.jma.go.jp/bosai/"
+
+        fun create(): JmaApi {
+
+            val client = OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build()
+
+            return Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(JmaApi::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaApi.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaApi.kt
@@ -1,5 +1,6 @@
 package com.pranshulgg.weather_master_app.core.network.sources.weather.jma
 
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.alerts.json.JmaWarningJson
 import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaAmedasCurrentJson
 import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaAmedasStationJson
 import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaAreaJson
@@ -40,6 +41,10 @@ interface JmaApi {
         @Path("amedasId") amedasId: String,
         @Path("dateHour") dateHour: String
     ): Map<String, JmaAmedasCurrentJson>
+
+    // officeCode = same one used for getForecast().
+    @GET("warning/data/warning/{officeCode}.json")
+    suspend fun getWarnings(@Path("officeCode") officeCode: String): JmaWarningJson
 
     companion object {
         const val BASE_URL = "https://www.jma.go.jp/bosai/"

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaConditionMap.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaConditionMap.kt
@@ -1,0 +1,166 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma
+
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherCondition
+
+object JmaConditionMap {
+
+    // The hourly (VPFD) endpoint's `weather` field only ever contains a single bare word per
+    // block, never the compound "A時々B"/"AのちB" phrases JMA's text bulletin uses elsewhere -
+    // confirmed live by sampling all 142 class10 regions in one pass. 晴れ/くもり/雨 were the
+    // only values actually observed (August, no snow season); 雪/雷/雨または雪 aren't covered by
+    // a direct match yet since they weren't seen live, so they fall through to the substring
+    // fallback below.
+    fun getCondition(weatherText: String?): WeatherCondition {
+        val text = weatherText?.trim()
+        if (text.isNullOrEmpty()) return WeatherCondition.NO_CONDITION_FOUND
+
+        return when (text) {
+            "晴れ" -> WeatherCondition.CLEAR_SKY
+            "くもり" -> WeatherCondition.OVERCAST
+            "雨" -> WeatherCondition.RAIN
+            "雪" -> WeatherCondition.SNOW
+            "雨または雪" -> WeatherCondition.SLEET
+            else -> when {
+                text.contains("雷") -> WeatherCondition.THUNDERSTORM
+                text.contains("雪") -> WeatherCondition.SNOW
+                text.contains("雨") -> WeatherCondition.RAIN
+                text.contains("曇") || text.contains("くもり") -> WeatherCondition.OVERCAST
+                text.contains("晴") -> WeatherCondition.CLEAR_SKY
+                else -> WeatherCondition.NO_CONDITION_FOUND
+            }
+        }
+    }
+
+    // The weekly forecast block uses a completely different, official numeric code system
+    // (3-digit "weatherCodes", e.g. "201"/"202") - not the plain-word field above. Table
+    // transcribed from the open-source Breezy Weather project's own JMA implementation
+    // (JMA_DAILY_WEATHER_CODES, GPLv3, github.com/breezy-weather/breezy-weather), which already
+    // did the legwork of mapping every code to its day/night meaning. Where day and night
+    // conditions differ and both have a THEN-composite in this app's WeatherCondition enum
+    // (CLEAR/CLOUDY/RAIN/SNOW), that composite is used; otherwise falls back to the day
+    // condition alone (this enum has no composite for PARTLY_CLOUDY/SLEET/THUNDERSTORM/FOG).
+    fun getDailyCondition(code: String?): WeatherCondition {
+        val normalized = code?.trim()
+        return when (normalized) {
+            "100" -> WeatherCondition.CLEAR_SKY
+            "101" -> WeatherCondition.PARTLY_CLOUDY
+            "102" -> WeatherCondition.RAIN
+            "103" -> WeatherCondition.RAIN
+            "104" -> WeatherCondition.SNOW
+            "105" -> WeatherCondition.SNOW
+            "106" -> WeatherCondition.SLEET
+            "107" -> WeatherCondition.SLEET
+            "108" -> WeatherCondition.THUNDERSTORM
+            "110" -> WeatherCondition.CLEAR_SKY
+            "111" -> WeatherCondition.CLEAR_THEN_CLOUDY
+            "112" -> WeatherCondition.CLEAR_THEN_RAIN
+            "113" -> WeatherCondition.CLEAR_THEN_RAIN
+            "114" -> WeatherCondition.CLEAR_THEN_RAIN
+            "115" -> WeatherCondition.CLEAR_THEN_SNOW
+            "116" -> WeatherCondition.CLEAR_THEN_SNOW
+            "117" -> WeatherCondition.CLEAR_THEN_SNOW
+            "118" -> WeatherCondition.CLEAR_SKY
+            "119" -> WeatherCondition.CLEAR_SKY
+            "120" -> WeatherCondition.CLEAR_THEN_RAIN
+            "121" -> WeatherCondition.RAIN_THEN_CLEAR
+            "122" -> WeatherCondition.CLEAR_THEN_RAIN
+            "123" -> WeatherCondition.CLEAR_SKY
+            "124" -> WeatherCondition.CLEAR_SKY
+            "125" -> WeatherCondition.THUNDERSTORM
+            "126" -> WeatherCondition.RAIN_THEN_CLEAR
+            "127" -> WeatherCondition.CLEAR_THEN_RAIN
+            "128" -> WeatherCondition.CLEAR_THEN_RAIN
+            "130" -> WeatherCondition.FOG_HAZE
+            "131" -> WeatherCondition.FOG_HAZE
+            "132" -> WeatherCondition.PARTLY_CLOUDY
+            "140" -> WeatherCondition.THUNDERSTORM
+            "160" -> WeatherCondition.SLEET
+            "170" -> WeatherCondition.SLEET
+            "181" -> WeatherCondition.CLEAR_SKY
+            "200" -> WeatherCondition.OVERCAST
+            "201" -> WeatherCondition.PARTLY_CLOUDY
+            "202" -> WeatherCondition.RAIN
+            "203" -> WeatherCondition.RAIN
+            "204" -> WeatherCondition.SNOW
+            "205" -> WeatherCondition.SNOW
+            "206" -> WeatherCondition.SNOW
+            "207" -> WeatherCondition.SLEET
+            "208" -> WeatherCondition.THUNDERSTORM
+            "209" -> WeatherCondition.FOG_HAZE
+            "210" -> WeatherCondition.OVERCAST
+            "211" -> WeatherCondition.CLOUDY_THEN_CLEAR
+            "212" -> WeatherCondition.CLOUDY_THEN_RAIN
+            "213" -> WeatherCondition.CLOUDY_THEN_RAIN
+            "214" -> WeatherCondition.CLOUDY_THEN_RAIN
+            "215" -> WeatherCondition.CLOUDY_THEN_SNOW
+            "216" -> WeatherCondition.CLOUDY_THEN_SNOW
+            "217" -> WeatherCondition.CLOUDY_THEN_SNOW
+            "218" -> WeatherCondition.OVERCAST
+            "219" -> WeatherCondition.OVERCAST
+            "220" -> WeatherCondition.RAIN
+            "221" -> WeatherCondition.RAIN_THEN_CLOUDY
+            "222" -> WeatherCondition.CLOUDY_THEN_RAIN
+            "223" -> WeatherCondition.PARTLY_CLOUDY
+            "224" -> WeatherCondition.RAIN_THEN_CLOUDY
+            "225" -> WeatherCondition.CLOUDY_THEN_RAIN
+            "226" -> WeatherCondition.CLOUDY_THEN_RAIN
+            "228" -> WeatherCondition.SNOW_THEN_CLOUDY
+            "229" -> WeatherCondition.CLOUDY_THEN_SNOW
+            "230" -> WeatherCondition.CLOUDY_THEN_SNOW
+            "231" -> WeatherCondition.OVERCAST
+            "240" -> WeatherCondition.THUNDERSTORM
+            "250" -> WeatherCondition.SNOW
+            "260" -> WeatherCondition.SLEET
+            "270" -> WeatherCondition.SLEET
+            "281" -> WeatherCondition.OVERCAST
+            "300" -> WeatherCondition.RAIN
+            "301" -> WeatherCondition.RAIN
+            "302" -> WeatherCondition.RAIN
+            "303" -> WeatherCondition.SLEET
+            "304" -> WeatherCondition.SLEET
+            "306" -> WeatherCondition.RAIN
+            "308" -> WeatherCondition.RAIN
+            "309" -> WeatherCondition.SLEET
+            "311" -> WeatherCondition.RAIN_THEN_CLEAR
+            "313" -> WeatherCondition.RAIN_THEN_CLOUDY
+            "314" -> WeatherCondition.RAIN_THEN_SNOW
+            "315" -> WeatherCondition.RAIN_THEN_SNOW
+            "316" -> WeatherCondition.SLEET
+            "317" -> WeatherCondition.SLEET
+            "320" -> WeatherCondition.RAIN_THEN_CLEAR
+            "321" -> WeatherCondition.RAIN_THEN_CLOUDY
+            "322" -> WeatherCondition.RAIN_THEN_SNOW
+            "323" -> WeatherCondition.RAIN_THEN_CLEAR
+            "324" -> WeatherCondition.RAIN_THEN_CLEAR
+            "325" -> WeatherCondition.RAIN_THEN_CLEAR
+            "326" -> WeatherCondition.RAIN_THEN_SNOW
+            "327" -> WeatherCondition.RAIN_THEN_SNOW
+            "328" -> WeatherCondition.RAIN
+            "329" -> WeatherCondition.SLEET
+            "340" -> WeatherCondition.SLEET
+            "350" -> WeatherCondition.THUNDERSTORM
+            "361" -> WeatherCondition.SLEET
+            "371" -> WeatherCondition.SLEET
+            "400" -> WeatherCondition.SNOW
+            "401" -> WeatherCondition.SNOW
+            "402" -> WeatherCondition.SNOW
+            "403" -> WeatherCondition.SLEET
+            "405" -> WeatherCondition.SNOW
+            "406" -> WeatherCondition.SNOW
+            "407" -> WeatherCondition.SNOW
+            "409" -> WeatherCondition.SLEET
+            "411" -> WeatherCondition.SNOW_THEN_CLEAR
+            "413" -> WeatherCondition.SNOW_THEN_CLOUDY
+            "414" -> WeatherCondition.SNOW_THEN_RAIN
+            "420" -> WeatherCondition.SNOW_THEN_CLEAR
+            "421" -> WeatherCondition.SNOW_THEN_CLOUDY
+            "422" -> WeatherCondition.SNOW_THEN_RAIN
+            "423" -> WeatherCondition.SNOW_THEN_RAIN
+            "425" -> WeatherCondition.SNOW
+            "426" -> WeatherCondition.SNOW
+            "427" -> WeatherCondition.SLEET
+            "450" -> WeatherCondition.SNOW
+            else -> WeatherCondition.NO_CONDITION_FOUND
+        }
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaRepository.kt
@@ -4,21 +4,29 @@ import com.pranshulgg.weather_master_app.core.model.domain.AppException
 import com.pranshulgg.weather_master_app.core.model.domain.location.Location
 import com.pranshulgg.weather_master_app.core.model.weather.WeatherResult
 import com.pranshulgg.weather_master_app.core.model.weather.WeatherResultType
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResult
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResultType
 import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaAmedasCurrentJson
 import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.model.JmaForecastBundle
 import com.pranshulgg.weather_master_app.core.utils.weather.cache.isWeatherCacheSafe
+import com.pranshulgg.weather_master_app.core.utils.weather.cache.shouldReturnAlertsCache
 import com.pranshulgg.weather_master_app.core.utils.weather.cache.shouldReturnWeatherCache
 import com.pranshulgg.weather_master_app.core.utils.weather.forecast.mergeHourlyWeather
+import com.pranshulgg.weather_master_app.data.local.dao.alerts.AlertsDao
 import com.pranshulgg.weather_master_app.data.local.dao.location.LocationKeysDao
 import com.pranshulgg.weather_master_app.data.local.dao.location.LocationsDao
 import com.pranshulgg.weather_master_app.data.local.dao.weather.WeatherDao
 import com.pranshulgg.weather_master_app.data.local.entity.location.LocationKeyEntity
+import com.pranshulgg.weather_master_app.data.local.mapper.alerts.toDomain
+import com.pranshulgg.weather_master_app.data.local.mapper.alerts.toEntity
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.jma.alerts.toDomain
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.jma.toDomain
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.toCurrentWeatherEntity
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.toDailyWeatherEntity
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.toDomain
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.toHourlyWeatherEntity
 import com.pranshulgg.weather_master_app.core.model.sources.Source
+import com.pranshulgg.weather_master_app.data.repository.data.AlertRepository
 import com.pranshulgg.weather_master_app.data.repository.data.WeatherRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -36,10 +44,12 @@ class JmaRepository @Inject constructor(
     val dao: LocationsDao,
     val weatherDao: WeatherDao,
     val api: JmaApi,
-    val locationKeysDao: LocationKeysDao
-) : WeatherRepository {
+    val locationKeysDao: LocationKeysDao,
+    val alertsDao: AlertsDao
+) : WeatherRepository, AlertRepository {
 
     override val weatherSource = Source.JMA
+    override val alertSource = Source.JMA
 
     override suspend fun getWeather(
         location: Location,
@@ -98,6 +108,41 @@ class JmaRepository @Inject constructor(
                 exception = e,
                 if (isCacheSafe) cache?.toDomain() else null
             )
+        }
+    }
+
+    override suspend fun getAlerts(
+        location: Location,
+        isManualRefresh: Boolean,
+        isForceRefresh: Boolean
+    ): AlertResult = withContext(Dispatchers.IO) {
+
+        val cache = alertsDao.getAlertsForLocation(location.id)
+        val shouldReturnCache = shouldReturnAlertsCache(
+            cache,
+            isManualRefresh,
+            isForceRefresh,
+            location.alertsLastFetchedAt
+        )
+
+        when (shouldReturnCache) {
+            AlertResultType.RETURN_CACHE -> return@withContext AlertResult.Success(cache.map { it!!.toDomain() })
+            else -> {}
+        }
+
+        return@withContext try {
+            val (class10Code, officeCode, _) = resolveLocation(location)
+                ?: return@withContext AlertResult.Error(exception = AppException.Unknown())
+
+            val domain = api.getWarnings(officeCode).toDomain(location.id, class10Code)
+
+            alertsDao.insertAlerts(domain.map { it.toEntity(location.id) }, location.id)
+            dao.updateAlertsLastFetchedAt(location.id, System.currentTimeMillis())
+
+            AlertResult.Success(domain)
+
+        } catch (e: Exception) {
+            AlertResult.Error(exception = e, cacheAlerts = cache.map { it!!.toDomain() })
         }
     }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/JmaRepository.kt
@@ -1,0 +1,175 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma
+
+import com.pranshulgg.weather_master_app.core.model.domain.AppException
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherResult
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherResultType
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaAmedasCurrentJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.model.JmaForecastBundle
+import com.pranshulgg.weather_master_app.core.utils.weather.cache.isWeatherCacheSafe
+import com.pranshulgg.weather_master_app.core.utils.weather.cache.shouldReturnWeatherCache
+import com.pranshulgg.weather_master_app.core.utils.weather.forecast.mergeHourlyWeather
+import com.pranshulgg.weather_master_app.data.local.dao.location.LocationKeysDao
+import com.pranshulgg.weather_master_app.data.local.dao.location.LocationsDao
+import com.pranshulgg.weather_master_app.data.local.dao.weather.WeatherDao
+import com.pranshulgg.weather_master_app.data.local.entity.location.LocationKeyEntity
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.jma.toDomain
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.toCurrentWeatherEntity
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.toDailyWeatherEntity
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.toDomain
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.toHourlyWeatherEntity
+import com.pranshulgg.weather_master_app.core.model.sources.Source
+import com.pranshulgg.weather_master_app.data.repository.data.WeatherRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+// The cached "city key" packs three values into one delimited string (LocationKeyEntity only
+// has a single cityKey column), so a warm-cache read needs zero extra network calls:
+// "{class10Code}|{officeCode}|{amedasId}".
+private const val CACHE_KEY_DELIMITER = "|"
+
+class JmaRepository @Inject constructor(
+    val dao: LocationsDao,
+    val weatherDao: WeatherDao,
+    val api: JmaApi,
+    val locationKeysDao: LocationKeysDao
+) : WeatherRepository {
+
+    override val weatherSource = Source.JMA
+
+    override suspend fun getWeather(
+        location: Location,
+        isManualRefresh: Boolean,
+        isForceRefresh: Boolean
+    ): WeatherResult = withContext(Dispatchers.IO) {
+
+        val cache = dao.getWeatherDataForLocation(location.id)
+        val shouldReturnCache = shouldReturnWeatherCache(cache, isManualRefresh, isForceRefresh)
+        val existingHourly = weatherDao.getHourlyDataForLocation(location.id, location.source)
+
+        when (shouldReturnCache) {
+            WeatherResultType.REFRESH_TOO_EARLY -> return@withContext WeatherResult.RefreshNotAvailable
+            WeatherResultType.SUCCESS -> return@withContext WeatherResult.Success(cache!!.toDomain())
+            else -> {}
+        }
+
+        val isCacheSafe = isWeatherCacheSafe(cache)
+
+        return@withContext try {
+
+            val (class10Code, officeCode, amedasId) = resolveLocation(location)
+                ?: return@withContext WeatherResult.Error(exception = AppException.Unknown())
+
+            val hourly = api.getHourly(class10Code)
+            val forecast = api.getForecast(officeCode)
+            // Current conditions are a nice-to-have on top of the forecast, not required for it -
+            // a failed AMeDAS fetch shouldn't fail the whole refresh.
+            val current = fetchAmedasCurrent(amedasId)
+
+            locationKeysDao.insertCityKey(
+                LocationKeyEntity(
+                    locationId = location.id,
+                    cityKey = "$class10Code$CACHE_KEY_DELIMITER$officeCode$CACHE_KEY_DELIMITER$amedasId"
+                )
+            )
+
+            val domain = JmaForecastBundle(hourly = hourly, forecast = forecast, current = current)
+                .toDomain(location)
+
+            val mergedHourly = mergeHourlyWeather(
+                existing = existingHourly,
+                incoming = domain.hourly.toHourlyWeatherEntity(location)
+            )
+            weatherDao.insertWeather(
+                domain.current.toCurrentWeatherEntity(location.id),
+                mergedHourly,
+                domain.daily.toDailyWeatherEntity(location.id),
+                location.id
+            )
+
+            WeatherResult.Success(domain)
+
+        } catch (e: Exception) {
+            WeatherResult.Error(
+                exception = e,
+                if (isCacheSafe) cache?.toDomain() else null
+            )
+        }
+    }
+
+    // Returns (class10Code, officeCode, amedasId), either from the cached composite key or by
+    // resolving fresh: nearest-match the user's coordinates against all 142 class10 regions,
+    // using each region's linked AMeDAS station (week_area.json) as its centroid.
+    private suspend fun resolveLocation(location: Location): Triple<String, String, String>? {
+        val cached = locationKeysDao.getCityKeyForLocation(location.id)?.cityKey
+        if (cached != null) {
+            val parts = cached.split(CACHE_KEY_DELIMITER)
+            if (parts.size == 3) return Triple(parts[0], parts[1], parts[2])
+        }
+
+        val class10s = api.getAreas().class10s.orEmpty()
+        val weekAreas = api.getWeekArea()
+        val amedasTable = api.getAmedasTable()
+
+        var closestCode: String? = null
+        var closestDistance = Float.MAX_VALUE
+
+        for ((code, info) in class10s) {
+            val amedasId = weekAreas[code]?.firstOrNull()?.amedas ?: continue
+            val station = amedasTable[amedasId] ?: continue
+            val lat = station.lat.toDecimalDegrees() ?: continue
+            val lon = station.lon.toDecimalDegrees() ?: continue
+
+            val results = FloatArray(1)
+            android.location.Location.distanceBetween(
+                location.latitude,
+                location.longitude,
+                lat,
+                lon,
+                results
+            )
+
+            if (results[0] < closestDistance) {
+                closestDistance = results[0]
+                closestCode = code
+            }
+        }
+
+        val class10Code = closestCode ?: return null
+        val officeCode = class10s[class10Code]?.parent ?: return null
+        val amedasId = weekAreas[class10Code]?.firstOrNull()?.amedas ?: return null
+
+        return Triple(class10Code, officeCode, amedasId)
+    }
+
+    // AMeDAS per-station files are only published at 3-hour boundaries (00/03/06/09/12/15/18/21
+    // JST) and keep accumulating 10-min entries under that same file name until the next
+    // boundary, so the request needs to floor to it rather than use the literal current hour.
+    // The just-started bucket can also 404 for a few minutes right after the boundary, before
+    // JMA publishes its first entry - fall back one bucket further back in that case.
+    private suspend fun fetchAmedasCurrent(amedasId: String): JmaAmedasCurrentJson? {
+        val now = ZonedDateTime.now(ZoneId.of("Asia/Tokyo"))
+        val flooredHour = (now.hour / 3) * 3
+        val boundary = now.withHour(flooredHour).withMinute(0).withSecond(0).withNano(0)
+
+        for (bucket in listOf(boundary, boundary.minusHours(3))) {
+            val path = bucket.format(DateTimeFormatter.ofPattern("yyyyMMdd_HH"))
+            try {
+                val result = api.getAmedasCurrent(amedasId, path).entries.maxByOrNull { it.key }?.value
+                if (result != null) return result
+            } catch (e: Exception) {
+                // try the previous bucket
+            }
+        }
+        return null
+    }
+}
+
+private fun List<Double>?.toDecimalDegrees(): Double? {
+    if (this == null || size < 2) return null
+    return this[0] + this[1] / 60.0
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/alerts/json/JmaWarningJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/alerts/json/JmaWarningJson.kt
@@ -1,0 +1,24 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma.alerts.json
+
+// areaTypes[0] uses the same class10 codes the weather source already resolves/caches (e.g.
+// "130010"), so no extra location resolution is needed to find "our" area in the response.
+data class JmaWarningJson(
+    val reportDatetime: String?,
+    val publishingOffice: String?,
+    val headlineText: String?,
+    val areaTypes: List<JmaWarningAreaTypeJson>?
+)
+
+data class JmaWarningAreaTypeJson(
+    val areas: List<JmaWarningAreaJson>?
+)
+
+data class JmaWarningAreaJson(
+    val code: String?,
+    val warnings: List<JmaWarningEntryJson>?
+)
+
+data class JmaWarningEntryJson(
+    val code: String?,
+    val status: String?
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaAmedasCurrentJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaAmedasCurrentJson.kt
@@ -1,0 +1,15 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json
+
+// getAmedasCurrent() response is Map<timestampKey, JmaAmedasCurrentJson>, one entry per 10-min
+// reading in the requested hour - take the entry with the max timestamp key for "current".
+// Every field is a [value, qualityFlag] pair - use .value() below, ignore the flag.
+data class JmaAmedasCurrentJson(
+    val temp: List<Double>? = null,
+    val humidity: List<Double>? = null,
+    val wind: List<Double>? = null, // m/s
+    val windDirection: List<Double>? = null, // 1-16 compass index
+    val precipitation1h: List<Double>? = null,
+    val pressure: List<Double>? = null // only present for major stations
+)
+
+fun List<Double>?.value(): Double? = this?.firstOrNull()

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaAmedasStationJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaAmedasStationJson.kt
@@ -1,0 +1,9 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json
+
+// Top-level response is Map<amedasId, JmaAmedasStationJson>.
+// lat/lon are [degrees, minutes] pairs, not decimal degrees - convert via deg + min/60.
+data class JmaAmedasStationJson(
+    val lat: List<Double>? = null,
+    val lon: List<Double>? = null,
+    val enName: String? = null
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaAreaJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaAreaJson.kt
@@ -1,0 +1,13 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json
+
+// Only class10s is modeled - Gson ignores the JSON's other top-level keys
+// (centers/offices/class15s/class20s) automatically since they're not declared here.
+data class JmaAreaJson(
+    val class10s: Map<String, JmaClass10Json>? = null
+)
+
+data class JmaClass10Json(
+    val name: String? = null,
+    val enName: String? = null,
+    val parent: String? = null
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaForecastJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaForecastJson.kt
@@ -1,0 +1,23 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json
+
+// getForecast() returns a 2-element List<JmaForecastBlockJson>:
+// [0] near-term (~3 days): timeSeries[1] has real "pops" (precip probability, 6h blocks) -
+//     that's the only field used from this block, broadcast onto the hourly VPFD timeline.
+// [1] weekly (7 days): already one entry per day (no 12h-block grouping needed, unlike CWA) -
+//     weatherCodes/pops/reliabilities in one timeSeries, tempsMin/tempsMax in another.
+// One shape is reused for both blocks since the fields present just differ per block.
+data class JmaForecastBlockJson(
+    val timeSeries: List<JmaTimeSeriesJson>? = null
+)
+
+data class JmaTimeSeriesJson(
+    val timeDefines: List<String>? = null,
+    val areas: List<JmaTimeSeriesAreaJson>? = null
+)
+
+data class JmaTimeSeriesAreaJson(
+    val weatherCodes: List<String>? = null,
+    val pops: List<String>? = null,
+    val tempsMin: List<String>? = null,
+    val tempsMax: List<String>? = null
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaHourlyJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaHourlyJson.kt
@@ -1,0 +1,32 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json
+
+// getHourly() response - the real 3-hourly numeric endpoint (bosai/jmatile/data/wdist/VPFD/).
+data class JmaHourlyJson(
+    val areaTimeSeries: JmaAreaTimeSeriesJson? = null,
+    val pointTimeSeries: JmaPointTimeSeriesJson? = null
+)
+
+data class JmaAreaTimeSeriesJson(
+    val timeDefines: List<JmaTimeDefineJson>? = null,
+    val weather: List<String>? = null,
+    val wind: List<JmaWindJson>? = null
+)
+
+data class JmaTimeDefineJson(
+    val dateTime: String? = null
+)
+
+// speed is a level number, not directly usable - range is the real "min max" m/s pair for
+// that level (e.g. "3 5"), use the midpoint.
+data class JmaWindJson(
+    val direction: String? = null,
+    val range: String? = null
+)
+
+// (maxTemperature/minTemperature also exist in the raw response as sparse daily markers, but
+// aren't modeled - real daily min/max comes from the weekly forecast block instead.)
+data class JmaPointTimeSeriesJson(
+    val pointNameEN: String? = null,
+    val timeDefines: List<JmaTimeDefineJson>? = null,
+    val temperature: List<Int>? = null
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaWeekAreaJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/json/JmaWeekAreaJson.kt
@@ -1,0 +1,10 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json
+
+// Top-level response is Map<class10Code, List<JmaWeekAreaEntryJson>> - no wrapper class needed.
+// "amedas" links a class10 region to its representative AMeDAS station id, used both for
+// current-conditions lookup and (via amedastable.json) as that region's resolution centroid.
+data class JmaWeekAreaEntryJson(
+    val srf: String? = null,
+    val week: String? = null,
+    val amedas: String? = null
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/model/JmaForecastBundle.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/jma/model/JmaForecastBundle.kt
@@ -1,0 +1,13 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.jma.model
+
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaAmedasCurrentJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaForecastBlockJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.JmaHourlyJson
+
+// forecast[0] = near-term (pops), forecast[1] = weekly (daily). current is null if the AMeDAS
+// fetch failed - the rest of the forecast is still usable without it.
+data class JmaForecastBundle(
+    val hourly: JmaHourlyJson,
+    val forecast: List<JmaForecastBlockJson>,
+    val current: JmaAmedasCurrentJson?
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/jma/JmaJsonMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/jma/JmaJsonMapper.kt
@@ -15,6 +15,7 @@ import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.model.
 import com.pranshulgg.weather_master_app.core.utils.extensions.DateTimeExtensions.normalizeToDay
 import com.pranshulgg.weather_master_app.core.utils.formatters.getCurrentTimeFor
 import com.pranshulgg.weather_master_app.core.utils.formatters.toSafeDouble
+import com.pranshulgg.weather_master_app.core.utils.weather.calculations.computeApparentTemperature
 import com.pranshulgg.weather_master_app.core.utils.weather.astronomy.getMoonTimings
 import com.pranshulgg.weather_master_app.core.utils.weather.astronomy.getSunTimings
 import com.pranshulgg.weather_master_app.core.utils.weather.forecast.findHourlyIndexForTime
@@ -106,6 +107,13 @@ fun JmaForecastBundle.toDomain(location: Location): Weather {
         ?.let { WindSpeedUnit.MPS.convert(it, WindSpeedUnit.KPH) }
     val amedasWindDirection = current?.windDirection.value()
         ?.let { WindDirection.toWindDirectionFromDegrees(amedasIndexToDegrees(it)) }
+    // AMeDAS doesn't report apparent temperature directly - compute it from its own real
+    // temp/humidity/wind (same convention as FMI/DWD/NWS/SMHI/etc use for this exact gap).
+    val amedasFeelsLike = computeApparentTemperature(
+        tempC = current?.temp.value(),
+        humidity = current?.humidity.value(),
+        windMs = current?.wind.value()
+    )
 
     return Weather(
         location = location,
@@ -119,7 +127,7 @@ fun JmaForecastBundle.toDomain(location: Location): Weather {
             cloudCover = null,
             uvIndex = null,
             weatherCondition = nearestHourPoint?.condition ?: WeatherCondition.NO_CONDITION_FOUND,
-            feelsLike = null,
+            feelsLike = amedasFeelsLike,
             time = currentTime,
             dewPoint = null,
             utcOffsetSeconds = null,

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/jma/JmaJsonMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/jma/JmaJsonMapper.kt
@@ -1,0 +1,223 @@
+package com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.jma
+
+import com.pranshulgg.weather_master_app.core.model.astro.MoonPhase
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.domain.weather.Weather
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherCurrent
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherDaily
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherHourly
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherCondition
+import com.pranshulgg.weather_master_app.core.model.weather.WindSpeedUnit
+import com.pranshulgg.weather_master_app.core.model.weather.wind.WindDirection
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.JmaConditionMap
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.json.value
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.model.JmaForecastBundle
+import com.pranshulgg.weather_master_app.core.utils.extensions.DateTimeExtensions.normalizeToDay
+import com.pranshulgg.weather_master_app.core.utils.formatters.getCurrentTimeFor
+import com.pranshulgg.weather_master_app.core.utils.formatters.toSafeDouble
+import com.pranshulgg.weather_master_app.core.utils.weather.astronomy.getMoonTimings
+import com.pranshulgg.weather_master_app.core.utils.weather.astronomy.getSunTimings
+import com.pranshulgg.weather_master_app.core.utils.weather.forecast.findHourlyIndexForTime
+import java.time.OffsetDateTime
+
+// JMA reports wind speed as a level+range in m/s (converted to km/h below) and temperature
+// already in Celsius. The forecast product has no rain/snow-amount field at all (only
+// probability), so rain/snowfall are always 0.0/null here, same treatment IPMA/AEMET/CWA use
+// for the same reason.
+
+private data class JmaHourPoint(
+    val time: Long,
+    val condition: WeatherCondition,
+    val temperature: Double?,
+    val precipitationProbability: Int?,
+    val windDirection: WindDirection?,
+    val windSpeed: Double?
+)
+
+fun JmaForecastBundle.toDomain(location: Location): Weather {
+
+    val timezone = location.timezone
+    val currentTime = getCurrentTimeFor(timezone)
+
+    val areaTs = hourly.areaTimeSeries
+    val pointTs = hourly.pointTimeSeries
+
+    val hourTimes = areaTs?.timeDefines.orEmpty().mapNotNull { it.dateTime.toEpochMillisOrNull() }
+    val temps = pointTs?.temperature.orEmpty()
+    val weatherWords = areaTs?.weather.orEmpty()
+    val winds = areaTs?.wind.orEmpty()
+
+    // Near-term block's pops (6h blocks, real precip probability) - broadcast onto the finer
+    // 3h VPFD timeline by finding each hour's enclosing pop block.
+    val nearTermArea = forecast.getOrNull(0)?.timeSeries?.getOrNull(1)?.areas?.firstOrNull()
+    val popTimeDefines = forecast.getOrNull(0)?.timeSeries?.getOrNull(1)?.timeDefines.orEmpty()
+        .mapNotNull { it.toEpochMillisOrNull() }
+    val pops = nearTermArea?.pops.orEmpty()
+
+    fun popAt(targetMillis: Long): Int? {
+        val index = popTimeDefines.indexOfLast { it <= targetMillis }
+        if (index == -1) return null
+        val blockEnd = popTimeDefines.getOrNull(index + 1) ?: (popTimeDefines[index] + 6 * 3_600_000L)
+        if (targetMillis >= blockEnd) return null
+        return pops.getOrNull(index)?.toSafeProbability()
+    }
+
+    val hourPoints = hourTimes.mapIndexed { index, t ->
+        val windEntry = winds.getOrNull(index)
+        JmaHourPoint(
+            time = t,
+            condition = JmaConditionMap.getCondition(weatherWords.getOrNull(index)),
+            temperature = temps.getOrNull(index)?.toDouble(),
+            precipitationProbability = popAt(t),
+            windDirection = jmaWindDirectionFromString(windEntry?.direction),
+            windSpeed = windEntry?.range.toMidpointMps()
+                ?.let { WindSpeedUnit.MPS.convert(it, WindSpeedUnit.KPH) }
+        )
+    }.sortedBy { it.time }
+
+    val currentIndex = findHourlyIndexForTime(hourPoints.map { it.time }, currentTime)
+    val nearestHourPoint = hourPoints.getOrNull(currentIndex)
+
+    // Daily - the weekly block is already one entry per day, no 12h-block grouping needed.
+    val weeklyConditionArea = forecast.getOrNull(1)?.timeSeries?.getOrNull(0)?.areas?.firstOrNull()
+    val weeklyTempsArea = forecast.getOrNull(1)?.timeSeries?.getOrNull(1)?.areas?.firstOrNull()
+
+    val dailyTimes = forecast.getOrNull(1)?.timeSeries?.getOrNull(0)?.timeDefines.orEmpty()
+        .mapNotNull { it.toEpochMillisOrNull() }
+
+    val weatherCodes = weeklyConditionArea?.weatherCodes.orEmpty()
+    val dailyPops = weeklyConditionArea?.pops.orEmpty()
+    val tempsMin = weeklyTempsArea?.tempsMin.orEmpty()
+    val tempsMax = weeklyTempsArea?.tempsMax.orEmpty()
+
+    // The weekly block leaves today's tempsMin/tempsMax as "" (confirmed live) since the
+    // near-term block covers today at finer granularity instead - fall back to the real
+    // hourly temps (which do cover today) so today's card isn't left blank.
+    val hourlyTempsByDay = hourPoints
+        .mapNotNull { p -> p.temperature?.let { p.time.normalizeToDay(timezone) to it } }
+        .groupBy({ it.first }, { it.second })
+
+    val sunTimings = getSunTimings(dailyTimes, timezone, location.latitude, location.longitude)
+    val moonTimings = getMoonTimings(dailyTimes, timezone, location.latitude, location.longitude)
+
+    // Current conditions: real numeric values from AMeDAS where available, condition derived
+    // from the nearest hourly point since AMeDAS has no sky-condition field of its own.
+    val amedasWindSpeed = current?.wind.value()
+        ?.let { WindSpeedUnit.MPS.convert(it, WindSpeedUnit.KPH) }
+    val amedasWindDirection = current?.windDirection.value()
+        ?.let { WindDirection.toWindDirectionFromDegrees(amedasIndexToDegrees(it)) }
+
+    return Weather(
+        location = location,
+        current = WeatherCurrent(
+            temperature = current?.temp.value() ?: nearestHourPoint?.temperature,
+            humidity = current?.humidity.value(),
+            windSpeed = amedasWindSpeed ?: nearestHourPoint?.windSpeed,
+            windDirection = amedasWindDirection ?: nearestHourPoint?.windDirection,
+            pressureMsl = current?.pressure.value(),
+            visibility = null,
+            cloudCover = null,
+            uvIndex = null,
+            weatherCondition = nearestHourPoint?.condition ?: WeatherCondition.NO_CONDITION_FOUND,
+            feelsLike = null,
+            time = currentTime,
+            dewPoint = null,
+            utcOffsetSeconds = null,
+            lastUpdatedInMilli = System.currentTimeMillis()
+        ),
+        hourly = hourPoints.map {
+            WeatherHourly(
+                temperature = it.temperature,
+                windSpeed = it.windSpeed,
+                windDirection = it.windDirection,
+                rain = 0.0,
+                snowfall = null,
+                uvIndex = null,
+                pressureMsl = null,
+                visibility = null,
+                humidity = null,
+                dewPoint = null,
+                weatherCondition = it.condition,
+                time = it.time,
+                precipitationProbability = it.precipitationProbability
+            )
+        },
+        daily = dailyTimes.mapIndexed { index, dayTime ->
+            val fallbackTemps = hourlyTempsByDay[dayTime.normalizeToDay(timezone)]
+            WeatherDaily(
+                temperatureMin = tempsMin.getOrNull(index)?.toSafeDouble()
+                    ?: fallbackTemps?.minOrNull(),
+                temperatureMax = tempsMax.getOrNull(index)?.toSafeDouble()
+                    ?: fallbackTemps?.maxOrNull(),
+                windSpeed = null,
+                windDirection = null,
+                rainSum = 0.0,
+                snowfallSum = null,
+                uvIndexMax = null,
+                weatherCondition = JmaConditionMap.getDailyCondition(weatherCodes.getOrNull(index)),
+                time = dayTime,
+                precipitationProbabilityMax = dailyPops.getOrNull(index)?.toSafeProbability(),
+                pressureMsl = null,
+                visibility = null,
+                humidity = null,
+                dewPoint = null,
+                sunrise = sunTimings.getOrNull(index)?.sunrise ?: 0L,
+                sunset = sunTimings.getOrNull(index)?.sunset ?: 0L,
+                moonrise = moonTimings.getOrNull(index)?.moonrise ?: 0L,
+                moonset = moonTimings.getOrNull(index)?.moonset ?: 0L,
+                moonPhase = moonTimings.getOrNull(index)?.phase ?: MoonPhase.NEW_MOON,
+                dawn = sunTimings.getOrNull(index)?.dawn ?: 0L,
+                dusk = sunTimings.getOrNull(index)?.dusk ?: 0L
+            )
+        }
+    )
+}
+
+private fun String?.toEpochMillisOrNull(): Long? {
+    if (this.isNullOrBlank()) return null
+    return try {
+        OffsetDateTime.parse(this).toInstant().toEpochMilli()
+    } catch (e: Exception) {
+        null
+    }
+}
+
+// JMA's precipitation probability is an empty string "" for the first (already-elapsed) block
+// of the near-term series - parsed as null so the UI hides it, same as every other source's
+// null precipitationProbability.
+private fun String?.toSafeProbability(): Int? {
+    if (this.isNullOrBlank()) return null
+    return toSafeDouble()?.toInt()
+}
+
+// "range" is a "min max" m/s pair (e.g. "3 5") - the actual usable value, unlike the bare
+// "speed" level number alongside it.
+private fun String?.toMidpointMps(): Double? {
+    val parts = this?.trim()?.split(" ") ?: return null
+    if (parts.size != 2) return null
+    val min = parts[0].toSafeDouble() ?: return null
+    val max = parts[1].toSafeDouble() ?: return null
+    return (min + max) / 2
+}
+
+// AMeDAS wind direction is a 1-16 compass index (1=N, clockwise, 0=calm/no wind).
+private fun amedasIndexToDegrees(index: Double): Int? {
+    val i = index.toInt()
+    if (i !in 1..16) return null
+    return ((i - 1) * 22.5).toInt()
+}
+
+// JMA reports wind direction as Japanese compass words, not English abbreviations.
+private fun jmaWindDirectionFromString(value: String?): WindDirection? {
+    return when (value?.trim()) {
+        "北" -> WindDirection.N
+        "北東" -> WindDirection.NE
+        "東" -> WindDirection.E
+        "南東" -> WindDirection.SE
+        "南" -> WindDirection.S
+        "南西" -> WindDirection.SW
+        "西" -> WindDirection.W
+        "北西" -> WindDirection.NW
+        else -> null // "静穏" (calm), blank, or unrecognized
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/jma/alerts/JmaAlertsMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/jma/alerts/JmaAlertsMapper.kt
@@ -1,0 +1,89 @@
+package com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.jma.alerts
+
+import com.pranshulgg.weather_master_app.core.model.domain.alerts.Alert
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertSeverity
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.alerts.json.JmaWarningJson
+import java.time.OffsetDateTime
+
+// Statuses seen live: "発表警報・注意報はなし" (none issued), "解除" (lifted) - both mean nothing
+// active; anything else (e.g. "継続" continuing, "発表" newly issued) is an active warning.
+private const val STATUS_NONE = "発表警報・注意報はなし"
+private const val STATUS_LIFTED = "解除"
+
+fun JmaWarningJson.toDomain(locationId: String, class10Code: String): List<Alert> {
+    val reportTime = reportDatetime?.toEpochMillisOrNull()
+
+    // areaTypes[0] is the class10-level group - the same granularity/codes this source's
+    // weather side already resolves to, so class10Code matches an area code here directly.
+    val area = areaTypes?.firstOrNull()?.areas?.firstOrNull { it.code == class10Code }
+        ?: return emptyList()
+
+    return area.warnings.orEmpty()
+        .filter { it.status != STATUS_NONE && it.status != STATUS_LIFTED }
+        .mapNotNull { warning ->
+            val event = jmaWarningName(warning.code) ?: return@mapNotNull null
+            Alert(
+                locationId = locationId,
+                event = event,
+                severity = jmaWarningSeverity(warning.code),
+                effective = reportTime,
+                expires = null,
+                description = headlineText?.trim().orEmpty(),
+                source = publishingOffice?.trim(),
+                lastUpdatedInMilli = System.currentTimeMillis()
+            )
+        }
+}
+
+// Transcribed from JMA's own warning-code enumeration (via Breezy Weather's JmaService.kt,
+// same technique used to find the hourly-forecast endpoint - JMA doesn't publish this table
+// itself). "+" suffix codes (e.g. "19+") are a slightly-elevated variant of the base code.
+private fun jmaWarningName(code: String?): String? = when (code) {
+    "33" -> "Heavy Rain Emergency Warning"
+    "03" -> "Heavy Rain Warning"
+    "10" -> "Heavy Rain Advisory"
+    "04" -> "Flood Warning"
+    "18" -> "Flood Advisory"
+    "35" -> "Storm Emergency Warning"
+    "05" -> "Storm Warning"
+    "15" -> "Gale Advisory"
+    "32" -> "Snowstorm Emergency Warning"
+    "02" -> "Snowstorm Warning"
+    "13" -> "Gale and Snow Advisory"
+    "36" -> "Heavy Snow Emergency Warning"
+    "06" -> "Heavy Snow Warning"
+    "12" -> "Heavy Snow Advisory"
+    "37" -> "High Wave Emergency Warning"
+    "07" -> "High Wave Warning"
+    "16" -> "High Wave Advisory"
+    "38" -> "Storm Surge Emergency Warning"
+    "08" -> "Storm Surge Warning"
+    "19+", "19" -> "Storm Surge Advisory"
+    "14" -> "Thunderstorm Advisory"
+    "17" -> "Snow Melting Advisory"
+    "20" -> "Dense Fog Advisory"
+    "21" -> "Dry Air Advisory"
+    "22" -> "Avalanche Advisory"
+    "23" -> "Low Temperature Advisory"
+    "24" -> "Frost Advisory"
+    "25" -> "Ice Accretion Advisory"
+    "26" -> "Snow Accretion Advisory"
+    else -> null
+}
+
+private fun jmaWarningSeverity(code: String?): AlertSeverity = when (code) {
+    "33" -> AlertSeverity.CRITICAL
+    "35", "32", "36", "37", "38", "08" -> AlertSeverity.HIGH
+    "03", "04", "05", "02", "06", "07", "19+" -> AlertSeverity.MODERATE
+    "10", "18", "15", "13", "12", "16", "19", "14", "17",
+    "20", "21", "22", "23", "24", "25", "26" -> AlertSeverity.LOW
+    else -> AlertSeverity.UNKNOWN
+}
+
+private fun String.toEpochMillisOrNull(): Long? {
+    return try {
+        OffsetDateTime.parse(this).toInstant().toEpochMilli()
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/provider/SourceRepositoryProvider.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/provider/SourceRepositoryProvider.kt
@@ -15,6 +15,7 @@ import com.pranshulgg.weather_master_app.core.network.sources.weather.fmi.FmiRep
 import com.pranshulgg.weather_master_app.core.network.sources.weather.gismeteo.GismeteoRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.imd.ImdRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.ipma.IpmaRepository
+import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.JmaRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.meteoam.MeteoamRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.meteofrance.MeteoFranceRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.metnorway.MetNorwayRepository
@@ -48,6 +49,7 @@ class SourceRepositoryProvider @Inject constructor(
     private val imdRepository: ImdRepository,
     private val pirateWeatherRepository: PirateWeatherRepository,
     private val cwaRepository: CwaRepository,
+    private val jmaRepository: JmaRepository,
 
     // ALERTS
     private val alertsWeatherApiRepository: AlertsWeatherApiRepository,
@@ -76,6 +78,7 @@ class SourceRepositoryProvider @Inject constructor(
         imdRepository,
         pirateWeatherRepository,
         cwaRepository,
+        jmaRepository,
         alertsWeatherApiRepository,
         wmoSevereWeatherRepository,
         fpasRepository,

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/repository/data/SourceDataRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/repository/data/SourceDataRepository.kt
@@ -21,8 +21,8 @@ class SourceDataRepository @Inject constructor(
         isForceRefreshForAirQuality: Boolean = false,
         isForceRefreshForAlerts: Boolean = false,
         onWeather: suspend (WeatherResult) -> Unit,
-        onAlerts: suspend (AlertResult) -> Unit,
-        onAirQuality: suspend (AirQualityResult) -> Unit,
+        onAlerts: suspend (AlertResult?) -> Unit,
+        onAirQuality: suspend (AirQualityResult?) -> Unit,
     ) = coroutineScope {
 
         val weatherSource = location.source
@@ -47,25 +47,20 @@ class SourceDataRepository @Inject constructor(
                 weatherJob.await()
 
                 val repo = sourceRepositoryProvider.getAlertRepository(alertSource)
-
-                if (repo != null) {
-                    onAlerts(repo.getAlerts(location = location))
-                }
+                onAlerts(repo?.getAlerts(location = location))
             }
 
         } else {
             launch {
                 val repo = sourceRepositoryProvider.getAlertRepository(alertSource)
 
-                if (repo != null) {
-                    onAlerts(
-                        repo.getAlerts(
-                            location = location,
-                            isManualRefresh = isManualRefresh,
-                            isForceRefresh = isForceRefreshForAlerts
-                        )
+                onAlerts(
+                    repo?.getAlerts(
+                        location = location,
+                        isManualRefresh = isManualRefresh,
+                        isForceRefresh = isForceRefreshForAlerts
                     )
-                }
+                )
             }
         }
 
@@ -74,25 +69,20 @@ class SourceDataRepository @Inject constructor(
                 weatherJob.await()
 
                 val repo = sourceRepositoryProvider.getAirQualityRepository(airQualitySource)
-
-                if (repo != null) {
-                    onAirQuality(repo.getAirQuality(location = location))
-                }
+                onAirQuality(repo?.getAirQuality(location = location))
             }
 
         } else {
             launch {
                 val repo = sourceRepositoryProvider.getAirQualityRepository(airQualitySource)
 
-                if (repo != null) {
-                    onAirQuality(
-                        repo.getAirQuality(
-                            location = location,
-                            isManualRefresh = isManualRefresh,
-                            isForceRefresh = isForceRefreshForAirQuality
-                        )
+                onAirQuality(
+                    repo?.getAirQuality(
+                        location = location,
+                        isManualRefresh = isManualRefresh,
+                        isForceRefresh = isForceRefreshForAirQuality
                     )
-                }
+                )
             }
         }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
@@ -115,16 +115,10 @@ class WeatherViewModel @Inject constructor(
         setLoading(true)
         weatherJob?.cancel()
         val startTime = System.currentTimeMillis()
-        // Reset alerts/airQuality here, not just on a successful result: getData() only invokes
-        // onAlerts/onAirQuality when the location's alertSource/airQualitySource resolves to a
-        // real repository (e.g. NONE never does) - without this, switching to a location with no
-        // alert source left the previous location's alerts on screen indefinitely.
         _uiState.value = _uiState.value.copy(
             isError = false,
             isUnsupportedSource = false,
-            isAirQualityLoading = true,
-            alerts = emptyList(),
-            airQuality = null
+            isAirQualityLoading = true
         )
 
 
@@ -347,8 +341,18 @@ class WeatherViewModel @Inject constructor(
     }
 
     private fun handleAirQuality(
-        result: AirQualityResult
+        result: AirQualityResult?
     ) {
+
+        // No repository resolves for this location's airQualitySource (e.g. NONE) - clear
+        // rather than leaving a previous location's air quality on screen.
+        if (result == null) {
+            _uiState.value = _uiState.value.copy(
+                airQuality = null,
+                isAirQualityLoading = false
+            )
+            return
+        }
 
         when (result) {
             is AirQualityResult.Success -> {
@@ -372,7 +376,14 @@ class WeatherViewModel @Inject constructor(
     }
 
 
-    private fun handleAlerts(result: AlertResult) {
+    private fun handleAlerts(result: AlertResult?) {
+
+        // No repository resolves for this location's alertSource (e.g. NONE) - clear rather
+        // than leaving a previous location's alerts on screen.
+        if (result == null) {
+            _uiState.value = _uiState.value.copy(alerts = emptyList())
+            return
+        }
 
         when (result) {
             is AlertResult.Success -> {

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
@@ -115,10 +115,16 @@ class WeatherViewModel @Inject constructor(
         setLoading(true)
         weatherJob?.cancel()
         val startTime = System.currentTimeMillis()
+        // Reset alerts/airQuality here, not just on a successful result: getData() only invokes
+        // onAlerts/onAirQuality when the location's alertSource/airQualitySource resolves to a
+        // real repository (e.g. NONE never does) - without this, switching to a location with no
+        // alert source left the previous location's alerts on screen indefinitely.
         _uiState.value = _uiState.value.copy(
             isError = false,
             isUnsupportedSource = false,
-            isAirQualityLoading = true
+            isAirQualityLoading = true,
+            alerts = emptyList(),
+            airQuality = null
         )
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -422,6 +422,7 @@
     <string name="country_finland">Finland</string>
     <string name="country_indonesia">Indonesia</string>
     <string name="country_italy">Italy</string>
+    <string name="country_japan">Japan</string>
     <string name="country_portugal">Portugal</string>
     <string name="country_russia">Russia</string>
     <string name="country_spain">Spain</string>


### PR DESCRIPTION

Closes #979.

Adds Japan's official JMA (Japan Meteorological Agency) as a new forecast
WeatherSource, requiring no API key — every endpoint it uses is fully public.

## Background

Earlier research on this issue concluded JMA's free data had no real hourly
forecast, only a coarse text bulletin, and that was posted as the answer on
the issue. That was wrong: it missed an endpoint JMA doesn't document
anywhere, found only by looking at how the open-source Breezy Weather
project implements JMA. That endpoint provides real 3-hourly numeric
temperature and wind, which is what this source is actually built on.

## Data sources

- Current conditions: AMeDAS, a live ~1,300-station observation network,
  updated every 10 minutes. Real numeric temperature, humidity, wind, and
  precipitation.
- Hourly forecast (~30 hours): a separate, undocumented endpoint providing
  real per-3-hour numeric temperature and wind, not a text summary.
- Daily forecast (7 days): JMA's weekly bulletin, already one entry per day
  with real min/max temperature and precipitation probability.

Location resolution is a single nearest-match step against JMA's 142
forecast regions, using each region's officially-linked observation station
as its reference point — resolved once per location and cached, not on
every refresh.

## Data that's derived rather than taken directly from one API field

A few values aren't a single direct read from the API, worth flagging
explicitly:

- **Today's daily high/low**: JMA's weekly forecast leaves today's min/max
  blank (confirmed by checking the raw response directly), since it expects
  the hourly data to cover today instead. This source fills that gap by
  computing today's min/max from its own real hourly temperatures, so
  today's card isn't left blank. Every other day comes directly from JMA's
  own daily field.
- **Wind speed**: JMA's hourly wind is reported as a level plus a min/max
  range (e.g. "3-5 m/s"), not a single value. This source uses the midpoint
  of that range.
- **Current weather condition**: the live observation network (AMeDAS) has
  no sky-condition field at all, only raw measurements. The condition shown
  for "current" is taken from the nearest hourly forecast point instead.
  The current temperature/humidity/wind/pressure values themselves are real
  live observations, not derived.

Where JMA simply doesn't have data (daily wind speed/direction, any
rain/snow amount), those fields are left null rather than approximated from
something else.

## Testing performed

Tested on a real device against the live JMA endpoints:
- Verified for Tokyo and for Naha (Okinawa) as a geographic edge case, to
  confirm the region-matching logic doesn't mis-resolve a location far from
  the endpoint that was tested during development.
- Confirmed current conditions, hourly, and daily all render real, sensible
  numbers for both locations, with clearly different data between the two
  (different temperatures, conditions, and precipitation chances matching
  each location's actual climate).
- Confirmed the today's-temperature fallback renders correctly instead of
  showing blank values.
- Confirmed caching: the region-resolution lookup only happens once per
  location, not on every refresh.

Two bugs were caught this way and fixed before opening this PR:
- Today's daily high/low was rendering blank, since JMA's own field is empty
  for the current day (see "Data that's derived" above for the fix).
- Current-conditions humidity/pressure/wind were silently falling back to
  forecast-derived values instead of real observations most of the time.
  Cause: AMeDAS's per-station observation file is only published at 3-hour
  JST boundaries (00/03/06/09/12/15/18/21), not every hour, so requesting
  the literal current hour 404'd outside those hours. Fixed by flooring to
  the current 3-hour boundary, with a fallback to the previous boundary for
  the few minutes right after each boundary before JMA publishes to it.

Rebased on top of `main` after both the source-architecture refactor and the
humidity-nullable change landed. On the latter: if a current-humidity
reading is genuinely unavailable (both AMeDAS attempts above fail), this
source now reports `null` rather than a misleading `0`, matching that new
convention.
