### PR TITLE
Fix a visible stutter/flash on every weather refresh

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/MainScreenScaffold.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/MainScreenScaffold.kt
@@ -134,6 +134,12 @@ fun MainScreenScaffold(
             ) {
                 AnimatedContent(
                     targetState = weather,
+                    // Keyed on the location, not the whole Weather object: a plain data
+                    // refresh produces a new Weather instance (different lastUpdatedInMilli
+                    // etc.) even when nothing visually changed, which made every refresh
+                    // full-screen crossfade instead of just recomposing the changed values -
+                    // only an actual location switch should get the transition.
+                    contentKey = { it?.location?.id },
                     transitionSpec = {
                         fadeIn() togetherWith fadeOut()
                     }


### PR DESCRIPTION
## What's happening

`MainScreenScaffold.kt` wraps the entire screen content (search bar,
current-conditions card, alerts, hourly, daily, every block) in a single
`AnimatedContent(targetState = weather, transitionSpec = { fadeIn()
togetherWith fadeOut() })`.

Since `weather` is a full `Weather` data class, a plain data refresh
produces a brand-new instance every time (different `lastUpdatedInMilli`
etc.) even when nothing visually changed. `AnimatedContent` treats that as
a completely new target state, so it fades out the whole old screen and
fades in a whole new one - full layout rebuild both times - on **every**
successful refresh, not just when actually switching to a different
location. That's real work on every refresh, not just a visual artifact,
and it's what produces the noticeable stutter/flash.

## Fix

Keyed the transition on the location id instead, using
`AnimatedContent`'s `contentKey` parameter:

```kt
AnimatedContent(
    targetState = weather,
    contentKey = { it?.location?.id },
    transitionSpec = {
        fadeIn() togetherWith fadeOut()
    }
)
```

Now a same-location refresh just recomposes the changed values in place
(no animation, no full-screen rebuild), while switching to a different
location still gets the intentional crossfade.

## Testing

Found while testing something unrelated (JMA alerts on PR #1047) -
confirmed the stutter/flash happens on any location, with or without
alerts, so it's unrelated to that work. Verified on-device (both an AVD
and a real phone) that repeated pull-to-refreshes on the same location no
longer show the flash, and switching between locations still transitions
normally.
