### PR TITLE
Fix BMKG forecast endpoint returning 403 Forbidden

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/bmkg/BmkgApi.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/bmkg/BmkgApi.kt
@@ -38,6 +38,17 @@ interface BmkgApi {
             val client = OkHttpClient.Builder()
                 .connectTimeout(30, TimeUnit.SECONDS)
                 .readTimeout(30, TimeUnit.SECONDS)
+                .addInterceptor { chain ->
+                    // BMKG's Cloudflare WAF rejects api/df/v1/forecast/coord with a 403
+                    // unless the request carries a same-origin Referer, matching their
+                    // own frontend's request pattern - confirmed live, doesn't affect
+                    // the other endpoint either way.
+                    val request = chain.request().newBuilder()
+                        .header("Referer", BASE_URL)
+                        .build()
+
+                    chain.proceed(request)
+                }
                 .build()
 
             return Retrofit.Builder()


### PR DESCRIPTION
Closes #1037, closes #1054.

## What was happening

BMKG's `api/df/v1/forecast/coord` endpoint was returning `403 Forbidden`, surfacing in the app as "Access to this resource was denied." (`api/presentwx/coord`, the current-conditions endpoint, wasn't affected.)

## Root cause

BMKG's site sits behind a Cloudflare WAF. Tested live against the real API: the forecast endpoint consistently rejects requests with no `Referer` header, regardless of `User-Agent` (tried none, curl's default, and OkHttp's actual default string - all 403). Adding a `Referer` matching their own site (`https://cuaca.bmkg.go.id/`) - the same thing their own frontend would send - gets a clean `200` every time. Confirmed reliable across repeated requests, and confirmed it doesn't affect the current-conditions endpoint either way.

## Fix

Added the `Referer` header via an OkHttp interceptor on `BmkgApi`'s client, same pattern already used for `User-Agent` elsewhere in the app (see `MetNorwayApi.kt`). Applied to both endpoints for simplicity since it's harmless on the one that didn't need it.

## Testing

- Verified the Referer requirement live against the real BMKG API (curl), isolating it from UA/other headers.
- Verified end-to-end through the actual app: added Jakarta as a BMKG-source location, confirmed real current + forecast data loads (temperature, condition, hourly forecast all populated, no error).
- Confirmed `BmkgApi`'s OkHttpClient is isolated (single call site, not shared with any other source), so this change can't affect anything else.

One caveat worth flagging: this was tested from a connection routed through Indonesia. From a connection that Cloudflare doesn't already trust, adding a Referer header alone wasn't enough in my testing (got a full WAF challenge page instead of a plain 403) - so this fix should resolve it for real Indonesian users on their own residential/mobile connections (BMKG's actual audience, and the #1054 reporter), but I can't fully rule out edge cases for traffic Cloudflare flags on other grounds.
