### PR TITLE
Add AMOLED (pure black) dark theme option

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/prefs/AppPrefs.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/prefs/AppPrefs.kt
@@ -14,6 +14,7 @@ object AppPrefs {
     private val _customThemeColor = mutableStateOf("#2196f3")
     private val _isCustomTheme = mutableStateOf(false)
     private val _isDynamicTheme = mutableStateOf(false)
+    private val _isAmoledTheme = mutableStateOf(false)
 
     private val _themeVariantType = mutableStateOf(ThemeVariantType.EXPRESSIVE)
 
@@ -42,6 +43,7 @@ object AppPrefs {
         _customThemeColor.value = PreferencesHelper.getString("custom_theme_color") ?: "#2196f3"
         _isCustomTheme.value = PreferencesHelper.getBool("isCustomTheme") ?: false
         _isDynamicTheme.value = PreferencesHelper.getBool("isDynamicTheme") ?: false
+        _isAmoledTheme.value = PreferencesHelper.getBool("isAmoledTheme") ?: false
 
         _themeVariantType.value = PreferencesHelper.getString("theme_variant_type")
             ?.let { runCatching { ThemeVariantType.valueOf(it) }.getOrNull() }
@@ -97,6 +99,12 @@ object AppPrefs {
         setDynamicColor = {
             _isDynamicTheme.value = it
             PreferencesHelper.setBool("isDynamicTheme", it)
+        },
+
+        isAmoledTheme = _isAmoledTheme.value,
+        setAmoledTheme = {
+            _isAmoledTheme.value = it
+            PreferencesHelper.setBool("isAmoledTheme", it)
         },
 
         themeVariantType = _themeVariantType.value,

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/prefs/AppPrefsState.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/prefs/AppPrefsState.kt
@@ -18,6 +18,9 @@ data class AppPrefsState(
     val isDynamicTheme: Boolean,
     val setDynamicColor: (Boolean) -> Unit,
 
+    val isAmoledTheme: Boolean,
+    val setAmoledTheme: (Boolean) -> Unit,
+
     val themeVariantType: ThemeVariantType,
     val setThemeVariantType: (ThemeVariantType) -> Unit,
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/ui/theme/Theme.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/ui/theme/Theme.kt
@@ -29,7 +29,9 @@ fun WeatherMasterTheme(
     applySystemUi: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
+    val prefs = LocalAppPrefs.current
+
+    val baseColorScheme = when {
         dynamicTheme && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
@@ -45,6 +47,16 @@ fun WeatherMasterTheme(
         }
     }
 
+    val colorScheme = if (darkTheme && prefs.isAmoledTheme) {
+        baseColorScheme.copy(
+            background = Color.Black,
+            surface = Color.Black,
+            surfaceContainer = Color.Black,
+        )
+    } else {
+        baseColorScheme
+    }
+
     val view = LocalView.current
     if (!view.isInEditMode) {
         if (applySystemUi) {
@@ -55,9 +67,6 @@ fun WeatherMasterTheme(
             }
         }
     }
-
-    val prefs = LocalAppPrefs.current
-
 
     MaterialExpressiveTheme(
         colorScheme = colorScheme,

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/settings/appearance/AppearanceScreen.kt
@@ -107,6 +107,21 @@ fun AppearanceScreen(navController: NavController) {
                         }
                     ),
 
+                    SettingTile.SwitchTile(
+                        leading = {
+                            SettingsTileIcon(
+                                R.drawable.circle_circle_24px
+                            )
+                        },
+                        title = stringResource(R.string.setting_amoled_theme),
+                        description = stringResource(R.string.setting_amoled_theme_secondary),
+                        checked = prefs.isAmoledTheme,
+                        enabled = prefs.appTheme != "Light",
+                        onCheckedChange = { checked ->
+                            prefs.setAmoledTheme(checked)
+                        }
+                    ),
+
                     SettingTile.DialogOptionTile(
                         leading = { SettingsTileIcon(R.drawable.font_download_24px) },
                         title = stringResource(R.string.setting_app_font),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,9 @@
     <string name="setting_dynamic_colors">Dynamic colors</string>
     <string name="setting_dynamic_colors_secondary">Use wallpaper colors</string>
 
+    <string name="setting_amoled_theme">AMOLED</string>
+    <string name="setting_amoled_theme_secondary">Use pure black in dark theme</string>
+
     <string name="weather_total_rain_day">Total rain for the day</string>
     <string name="error_network">Network unavailable</string>
     <string name="weather_total_snow_day">Total snow for the day</string>


### PR DESCRIPTION
Closes #245.

## What's new

Adds an "AMOLED" toggle in Appearance settings, next to Dynamic colors. When on (and the app theme is Dark), the background switches from the generated dark surface tone to pure black (#000000) — real power savings on AMOLED screens, and higher contrast. Only enabled while Dark is selected; if you switch to Light it stays saved and re-applies automatically when you switch back to Dark.

## Implementation

- New isAmoledTheme preference (AppPrefs.kt / AppPrefsState.kt), persisted the same way as the existing theme prefs.
- WeatherMasterTheme (Theme.kt) overrides background, surface, and surfaceContainer to pure black when darkTheme && isAmoledTheme. Those are the three tokens the app's screens actually paint their base background with (LargeTopBarScaffold uses surfaceContainer for its container color, not background). Left surfaceBright / surfaceContainerHigh / etc. untouched, so cards and tiles keep their existing elevation tones — there's still visible contrast between a card and the black background, instead of everything collapsing into one flat black.
- New switch tile in AppearanceScreen.kt, enabled only when appTheme != "Light".
- Doesn't touch the main weather screen, froggy, or the weather-based sky gradient — MainScreenScaffold.kt already manages its own background independently of the color scheme (black + a condition gradient when "Weather based theme" is on, a generated navy tone otherwise), and none of that reads background/surface/surfaceContainer, so it looks the same with this on or off either way.

## Testing

Verified live on an AVD and on a physical device: toggled on/off and checked the Locations list and Settings/Appearance itself — background goes true black in each, cards stay clearly visible via their generated surfaceBright/surfaceContainerHigh tones. Confirmed the toggle disables (but keeps its saved value) when switching to Light theme, and reactivates correctly switching back to Dark. Compiles clean, no other screens visibly regressed while navigating around with it on.


<img width="432" height="898" alt="Dark_PixelCard_tiny" src="https://github.com/user-attachments/assets/211114a0-d5c8-42c6-a73a-43506b080f58" />
<img width="432" height="899" alt="Dark_Settings_tiny" src="https://github.com/user-attachments/assets/a28c8ece-a9dd-4712-85cd-8841ed72d8b2" />
<img width="432" height="911" alt="DarkTheme_tiny" src="https://github.com/user-attachments/assets/e469c505-a56a-4f15-8035-cceebae4c7bf" />

