### PR TITLE
Add alerts support to NWS

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/WeatherRepositoryModule.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/WeatherRepositoryModule.kt
@@ -81,8 +81,9 @@ object WeatherRepositoryModule {
         api: NwsApi,
         dao: LocationsDao,
         weatherDao: WeatherDao,
-        nwsDao: NwsDao
-    ): NwsRepository = NwsRepository(dao, weatherDao, nwsDao, api)
+        nwsDao: NwsDao,
+        alertsDao: AlertsDao
+    ): NwsRepository = NwsRepository(dao, weatherDao, nwsDao, api, alertsDao)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
@@ -27,7 +27,7 @@ enum class Source(
         fullName = "National Weather Service",
         displayLink = "https://www.weather.gov/documentation/services-web-api",
         countryNameRes = R.string.country_usa,
-        capabilities = setOf(Capability.WEATHER)
+        capabilities = setOf(Capability.WEATHER, Capability.ALERTS)
     ),
     SMHI(
         displayName = "SMHI",

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/nws/NwsApi.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/nws/NwsApi.kt
@@ -1,5 +1,6 @@
 package com.pranshulgg.weather_master_app.core.network.sources.weather.nws
 
+import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.json.NwsAlertsJson
 import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.json.NwsCurrentForecastJson
 import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.json.NwsForecastJson
 import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.json.NwsGridPointDataJson
@@ -13,6 +14,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 import java.util.concurrent.TimeUnit
 
 
@@ -59,6 +61,11 @@ interface NwsApi {
         @Path("gridX") gridX: Long,
         @Path("gridY") gridY: Long
     ): Response<NwsGridPointDataJson>
+
+    @GET("alerts/active")
+    suspend fun fetchActiveAlerts(
+        @Query("point") point: String
+    ): Response<NwsAlertsJson>
 
     companion object {
         const val BASE_URL = "https://api.weather.gov/"

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/nws/NwsRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/nws/NwsRepository.kt
@@ -7,22 +7,30 @@ import com.pranshulgg.weather_master_app.core.model.domain.toAppException
 import com.pranshulgg.weather_master_app.core.model.sources.Source
 import com.pranshulgg.weather_master_app.core.model.weather.WeatherResult
 import com.pranshulgg.weather_master_app.core.model.weather.WeatherResultType
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResult
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResultType
 import com.pranshulgg.weather_master_app.core.network.calls.safeApiCall
 import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.json.NwsCurrentForecastJson
 import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.json.NwsStationsListJson
 import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.json.bundle.NwsWeatherJsonBundle
 import com.pranshulgg.weather_master_app.core.utils.weather.cache.isWeatherCacheSafe
+import com.pranshulgg.weather_master_app.core.utils.weather.cache.shouldReturnAlertsCache
 import com.pranshulgg.weather_master_app.core.utils.weather.cache.shouldReturnWeatherCache
 import com.pranshulgg.weather_master_app.core.utils.weather.forecast.mergeHourlyWeather
+import com.pranshulgg.weather_master_app.data.local.dao.alerts.AlertsDao
 import com.pranshulgg.weather_master_app.data.local.dao.location.LocationsDao
 import com.pranshulgg.weather_master_app.data.local.dao.weather.WeatherDao
 import com.pranshulgg.weather_master_app.data.local.dao.weather.nws.NwsDao
+import com.pranshulgg.weather_master_app.data.local.mapper.alerts.toDomain
+import com.pranshulgg.weather_master_app.data.local.mapper.alerts.toEntity
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.nws.alerts.toDomain
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.nws.toDomain
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.nws.toEntity
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.toCurrentWeatherEntity
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.toDailyWeatherEntity
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.toDomain
 import com.pranshulgg.weather_master_app.data.local.mapper.weather.toHourlyWeatherEntity
+import com.pranshulgg.weather_master_app.data.repository.data.AlertRepository
 import com.pranshulgg.weather_master_app.data.repository.data.WeatherRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -33,10 +41,12 @@ class NwsRepository @Inject constructor(
     val dao: LocationsDao,
     val weatherDao: WeatherDao,
     val nwsDao: NwsDao,
-    val api: NwsApi
-) : WeatherRepository {
+    val api: NwsApi,
+    val alertsDao: AlertsDao
+) : WeatherRepository, AlertRepository {
 
     override val weatherSource = Source.NWS
+    override val alertSource = Source.NWS
 
 
     override suspend fun getWeather(
@@ -194,6 +204,44 @@ class NwsRepository @Inject constructor(
 
             }
         }
+
+    override suspend fun getAlerts(
+        location: Location,
+        isManualRefresh: Boolean,
+        isForceRefresh: Boolean
+    ): AlertResult = withContext(Dispatchers.IO) {
+
+        val cache = alertsDao.getAlertsForLocation(location.id)
+        val shouldReturnCache = shouldReturnAlertsCache(
+            cache,
+            isManualRefresh,
+            isForceRefresh,
+            location.alertsLastFetchedAt
+        )
+
+        if (shouldReturnCache == AlertResultType.RETURN_CACHE) {
+            return@withContext AlertResult.Success(cache.map { it!!.toDomain() })
+        }
+
+        val point = "${location.latitude},${location.longitude}"
+
+        safeApiCall { api.fetchActiveAlerts(point) }.fold(
+            onSuccess = { body ->
+                val domain = body.toDomain(location.id)
+
+                alertsDao.insertAlerts(domain.map { it.toEntity(location.id) }, location.id)
+                dao.updateAlertsLastFetchedAt(location.id, System.currentTimeMillis())
+
+                AlertResult.Success(domain)
+            },
+            onFailure = { e ->
+                AlertResult.Error(
+                    exception = e as? Exception ?: Exception(e),
+                    cacheAlerts = cache.map { it!!.toDomain() }
+                )
+            }
+        )
+    }
 }
 
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/nws/json/NwsAlertsJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/nws/json/NwsAlertsJson.kt
@@ -1,0 +1,19 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.nws.json
+
+data class NwsAlertsJson(
+    val features: List<NwsAlertFeatureJson>?
+)
+
+data class NwsAlertFeatureJson(
+    val properties: NwsAlertPropertiesJson?
+)
+
+data class NwsAlertPropertiesJson(
+    val id: String?,
+    val event: String?,
+    val severity: String?,
+    val effective: String?,
+    val expires: String?,
+    val description: String?,
+    val senderName: String?
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/nws/alerts/NwsAlertsMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/nws/alerts/NwsAlertsMapper.kt
@@ -1,0 +1,40 @@
+package com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.nws.alerts
+
+import com.pranshulgg.weather_master_app.core.model.domain.alerts.Alert
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertSeverity
+import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.json.NwsAlertsJson
+import java.time.OffsetDateTime
+
+fun NwsAlertsJson.toDomain(locationId: String): List<Alert> {
+    return features.orEmpty().mapNotNull { feature ->
+        val properties = feature.properties ?: return@mapNotNull null
+        val event = properties.event ?: return@mapNotNull null
+
+        Alert(
+            locationId = locationId,
+            event = event,
+            severity = nwsAlertSeverity(properties.severity),
+            effective = properties.effective?.toEpochMillisOrNull(),
+            expires = properties.expires?.toEpochMillisOrNull(),
+            description = properties.description.orEmpty(),
+            source = properties.senderName,
+            lastUpdatedInMilli = System.currentTimeMillis()
+        )
+    }
+}
+
+private fun nwsAlertSeverity(severity: String?): AlertSeverity = when (severity) {
+    "Extreme" -> AlertSeverity.CRITICAL
+    "Severe" -> AlertSeverity.HIGH
+    "Moderate" -> AlertSeverity.MODERATE
+    "Minor" -> AlertSeverity.LOW
+    else -> AlertSeverity.UNKNOWN
+}
+
+private fun String.toEpochMillisOrNull(): Long? {
+    return try {
+        OffsetDateTime.parse(this).toInstant().toEpochMilli()
+    } catch (e: Exception) {
+        null
+    }
+}


### PR DESCRIPTION
Adds alerts support to NWS by having `NwsRepository` implement `AlertRepository`
as well as `WeatherRepository` (self-paired, same pattern as JMA/AccuWeather/
Pirate Weather/INMET).

## Background

NWS is the only recommended weather source for
the US (`Source.kt`'s country map), but it had no alerts capability, so every
US location got zero recommended alert sources in the Edit Location picker —
just the generic worldwide list (AccuWeather, Pirate Weather, Weather API,
WMO Severe Weather, FPAS).

NWS actually has a free, keyless alerts endpoint on the same host
`NwsRepository` already talks to: `/alerts/active?point={lat},{lon}`. It takes
a raw lat/lon directly (no gridpoint/office resolution needed), is already
server-side filtered to active alerts only, and returns standard CAP fields
(event, severity, effective/expires, description, sender).

## What changed

- `Source.NWS` gains `Capability.ALERTS`, so it now shows up as a recommended
  alert source for US locations automatically (the picker already filters
  generically by capability — no picker changes needed).
- `NwsRepository` implements `AlertRepository`, following the same
  cache/throttle pattern as this file's existing `getWeather()`.
- New `NwsAlertsJson` / `NwsAlertsMapper` for the response, mapping NWS's
  `Extreme/Severe/Moderate/Minor/Unknown` severity vocabulary directly onto
  this app's `AlertSeverity` enum.

## Testing performed

Tested on a real device against the live NWS API:
- Confirmed a US location with a real active alert (Denver, CO — an Air
  Quality Alert) renders correctly with the right event/severity/description
  once its alert source is set to NWS.
- Confirmed a US location with zero active alerts (New York, NY) shows the
  empty state, no crash.
- Confirmed the manual-refresh throttle behaves the same as other alert
  sources — rapid re-refresh returns cache instead of re-hitting the API.
