### PR TITLE
Auto-select a self-paired alert source to match the weather source

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/editlocation/EditLocationViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/editlocation/EditLocationViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pranshulgg.weather_master_app.core.model.sources.Capability
 import com.pranshulgg.weather_master_app.core.model.sources.Source
 import com.pranshulgg.weather_master_app.core.model.weather.openmeteo.OpenMeteoModel
 import com.pranshulgg.weather_master_app.data.repository.ApiKeysRepository
@@ -51,7 +52,14 @@ class EditLocationViewModel @Inject constructor(
     }
 
     fun updateSelectedWeatherSource(source: Source) {
-        _uiState.value = _uiState.value.copy(selectedWeatherSource = source)
+        _uiState.value = _uiState.value.copy(
+            selectedWeatherSource = source,
+            selectedAlertSource = if (Capability.ALERTS in source.capabilities) {
+                source
+            } else {
+                _uiState.value.selectedAlertSource
+            }
+        )
     }
 
     fun updateSelectedAlertSource(source: Source) {

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/editlocation/EditLocationViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/editlocation/EditLocationViewModel.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.pranshulgg.weather_master_app.core.model.sources.Capability
 import com.pranshulgg.weather_master_app.core.model.sources.Source
 import com.pranshulgg.weather_master_app.core.model.weather.openmeteo.OpenMeteoModel
 import com.pranshulgg.weather_master_app.data.repository.ApiKeysRepository
@@ -52,14 +51,7 @@ class EditLocationViewModel @Inject constructor(
     }
 
     fun updateSelectedWeatherSource(source: Source) {
-        _uiState.value = _uiState.value.copy(
-            selectedWeatherSource = source,
-            selectedAlertSource = if (Capability.ALERTS in source.capabilities) {
-                source
-            } else {
-                _uiState.value.selectedAlertSource
-            }
-        )
+        _uiState.value = _uiState.value.copy(selectedWeatherSource = source)
     }
 
     fun updateSelectedAlertSource(source: Source) {

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/search/SearchScreenViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/search/SearchScreenViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pranshulgg.weather_master_app.R
+import com.pranshulgg.weather_master_app.core.model.sources.Capability
 import com.pranshulgg.weather_master_app.core.model.sources.SearchSource
 import com.pranshulgg.weather_master_app.core.model.domain.location.Location
 import com.pranshulgg.weather_master_app.core.model.domain.toAppException
@@ -80,7 +81,12 @@ class SearchScreenViewModel @Inject constructor(
                 } else {
                     location
                 }
-                locationsRepo.saveLocation(resolved.copy(source = weatherSource))
+                val alertSource = if (Capability.ALERTS in weatherSource.capabilities) {
+                    weatherSource
+                } else {
+                    resolved.alertSource
+                }
+                locationsRepo.saveLocation(resolved.copy(source = weatherSource, alertSource = alertSource))
                 onBack()
             } catch (e: Exception) {
                 val appExpectation = e.toAppException()


### PR DESCRIPTION
Auto-selects a location's alert source whenever its weather source is one
that already serves alerts itself (JMA, AccuWeather, Pirate Weather, INMET,
and NWS once #1070 lands), instead of leaving alert source on `None` until
the user separately opens the alert-source picker and picks it by hand.

## Background

Found this while testing NWS alerts (#1070): a brand-new US location picks
NWS as its recommended weather source automatically, but alert source stays
unset regardless, so alerts silently never fetch until you go into Edit
Location and pick a source there too. That gap isn't NWS-specific — any
self-paired source (weather source that also has `Capability.ALERTS`)
behaves the same way today, since the weather-source picker and the
alert-source picker have never been linked.

## What changed

- **New location**: `SearchScreenViewModel.saveLocation` now sets
  `alertSource` to match the chosen weather source when that source has
  `Capability.ALERTS`, at the same point it already sets `source`.
- **Editing an existing location**: `EditLocationViewModel.updateSelectedWeatherSource`
  auto-updates `selectedAlertSource` in the same UI-state update whenever the
  newly picked weather source is self-paired.
- In both cases, picking a weather source that *isn't* self-paired leaves
  whatever alert source was already selected untouched — so a deliberately
  mixed pairing (e.g. AccuWeather for weather, WMO Severe Weather for
  alerts) still works exactly as before. This only ever sets alert source
  automatically; it never clears one.

## Testing performed

Tested live on the AVD:
- A brand-new Japan location auto-pairs JMA for both weather and alerts —
  confirmed via the on-device Room DB (`alertSource` = `JMA`, not `NONE`)
  without ever opening the alert-source picker.
- Editing an existing location and switching its weather source to
  AccuWeather updates the Edit Location screen's alert-source tile to
  AccuWeather immediately, before tapping Save; confirmed it persists
  correctly after saving.
- Switching that same location's weather source on to a non-self-paired
  source (Open Meteo) leaves the alert source on the prior pick
  (AccuWeather) instead of clearing it back to `None`.
