### PR TITLE
Refactor: moved business logic to Use Cases and added unit test suite

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,7 +154,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.materialKolor)
-    implementation(libs.androidx.foundation.layout) // Removed duplicate entry
+    implementation(libs.androidx.foundation.layout)
     implementation(libs.coil.compose)
     implementation(libs.kotlinx.coroutines.android)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,7 @@ android {
         buildConfigField(
             "String",
             "APP_VERSION",
-            "\"v$versionNameString\""
+            "\"v${versionNameString}\""
         )
 
         buildConfigField(

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,7 +57,7 @@ android {
         buildConfigField(
             "String",
             "GEO_NAMES_USERNAME",
-            "\"$geoNamesUserNameKey\""
+            "\"$geoNamesUserNameKey\"",
         )
 
         buildConfigField(
@@ -81,7 +81,7 @@ android {
         buildConfigField(
             "String",
             "APP_VERSION",
-            "\"v${versionNameString}\""
+            "\"v$versionNameString\"",
         )
 
         buildConfigField(
@@ -174,7 +174,6 @@ dependencies {
     ksp(libs.hilt.android.compiler)
     ksp(libs.hilt.compiler)
     implementation(libs.reorderable)
-    implementation(libs.androidx.foundation.layout)
     implementation(libs.androidx.animation.core)
     implementation(libs.core.splashscreen)
 
@@ -188,6 +187,9 @@ dependencies {
 
     implementation(libs.kotlinx.serialization.json)
     testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,7 +57,7 @@ android {
         buildConfigField(
             "String",
             "GEO_NAMES_USERNAME",
-            "\"$geoNamesUserNameKey\"",
+            "\"$geoNamesUserNameKey\""
         )
 
         buildConfigField(
@@ -81,7 +81,7 @@ android {
         buildConfigField(
             "String",
             "APP_VERSION",
-            "\"v$versionNameString\"",
+            "\"v$versionNameString\""
         )
 
         buildConfigField(

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,7 +154,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.materialKolor)
-    implementation(libs.androidx.foundation.layout)
+    implementation(libs.androidx.foundation.layout) // Removed duplicate entry
     implementation(libs.coil.compose)
     implementation(libs.kotlinx.coroutines.android)
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/repository/data/SourceDataRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/repository/data/SourceDataRepository.kt
@@ -90,6 +90,6 @@ class SourceDataRepository @Inject constructor(
             onWeather(weatherJob.await())
         }
 
-
+        Unit
     }
 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/repository/data/SourceDataRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/repository/data/SourceDataRepository.kt
@@ -89,7 +89,5 @@ class SourceDataRepository @Inject constructor(
         launch {
             onWeather(weatherJob.await())
         }
-
-        Unit
     }
 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/DeleteLocationUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/DeleteLocationUseCase.kt
@@ -1,0 +1,12 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
+import javax.inject.Inject
+
+class DeleteLocationUseCase @Inject constructor(
+    private val locationsRepo: LocationsRepository
+) {
+    suspend operator fun invoke(id: String) {
+        locationsRepo.deleteLocation(id)
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/DeleteLocationUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/DeleteLocationUseCase.kt
@@ -1,5 +1,9 @@
 package com.pranshulgg.weather_master_app.domain.usecase
 
+/**
+ * Initial Clean Architecture Domain Layer integration implemented by https://github.com/gietabhi10
+ */
+
 import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
 import javax.inject.Inject
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/DeleteLocationUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/DeleteLocationUseCase.kt
@@ -3,6 +3,9 @@ package com.pranshulgg.weather_master_app.domain.usecase
 import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
 import javax.inject.Inject
 
+/**
+ * Use case to delete a location and its associated data from the local database.
+ */
 class DeleteLocationUseCase @Inject constructor(
     private val locationsRepo: LocationsRepository
 ) {

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
@@ -28,8 +28,6 @@ class GetWeatherUseCase @Inject constructor(
      * asynchronous operations.
      *
      * All callbacks are invoked on the dispatcher used by the caller.
-     * Note: [onWeather], [onAlerts], and [onAirQuality] may be invoked from the
-     * repository's dispatcher if not explicitly controlled by the caller.
      *
      * @param location The location to fetch data for.
      * @param isManualRefresh Whether this is a user-initiated refresh (e.g., pull-to-refresh).

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
@@ -1,0 +1,53 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherResult
+import com.pranshulgg.weather_master_app.core.model.weather.airquality.AirQualityResult
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResult
+import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
+import com.pranshulgg.weather_master_app.data.repository.data.SourceDataRepository
+import javax.inject.Inject
+
+class GetWeatherUseCase @Inject constructor(
+    private val locationsRepo: LocationsRepository,
+    private val sourceDataRepository: SourceDataRepository
+) {
+    suspend operator fun invoke(
+        location: Location,
+        isManualRefresh: Boolean = false,
+        isForceRefresh: Boolean = false,
+        isForceRefreshForAirQuality: Boolean = false,
+        isForceRefreshForAlerts: Boolean = false,
+        onWeather: suspend (WeatherResult, Location) -> Unit,
+        onAlerts: suspend (AlertResult?) -> Unit,
+        onAirQuality: suspend (AirQualityResult?) -> Unit,
+    ) {
+        var effectiveLocation = location
+        var effectiveForceRefresh = isForceRefresh
+        var effectiveForceRefreshForAirQuality = isForceRefreshForAirQuality
+        var effectiveForceRefreshForAlerts = isForceRefreshForAlerts
+
+        if (location.isDeviceLocation) {
+            val positionChanged = locationsRepo.updateDeviceLocationPosition()
+            if (positionChanged) {
+                effectiveLocation = locationsRepo.getLocationForId(location.id)
+                effectiveForceRefresh = true
+                effectiveForceRefreshForAirQuality = true
+                effectiveForceRefreshForAlerts = true
+            }
+        }
+
+        sourceDataRepository.getData(
+            location = effectiveLocation,
+            isManualRefresh = isManualRefresh,
+            isForceRefresh = effectiveForceRefresh,
+            isForceRefreshForAirQuality = effectiveForceRefreshForAirQuality,
+            isForceRefreshForAlerts = effectiveForceRefreshForAlerts,
+            onWeather = { result ->
+                onWeather(result, effectiveLocation)
+            },
+            onAlerts = onAlerts,
+            onAirQuality = onAirQuality
+        )
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
@@ -8,16 +8,33 @@ import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
 import com.pranshulgg.weather_master_app.data.repository.data.SourceDataRepository
 import javax.inject.Inject
 
+/**
+ * Orchestrates the fetching of weather, alerts, and air quality data for a given location.
+ */
 class GetWeatherUseCase @Inject constructor(
     private val locationsRepo: LocationsRepository,
     private val sourceDataRepository: SourceDataRepository
 ) {
+    /**
+     * Executes the weather fetch process.
+     *
+     * @param location The location to fetch data for.
+     * @param isManualRefresh Whether this is a user-initiated refresh (e.g., pull-to-refresh).
+     * @param isForceRefresh Whether to bypass caches for weather data.
+     * @param isForceRefreshForAirQuality Whether to bypass caches for air quality data.
+     * @param isForceRefreshForAlerts Whether to bypass caches for alerts.
+     * @param onLocationUpdated Callback invoked immediately if the device location's coordinates are updated.
+     * @param onWeather Callback invoked when weather data is successfully fetched or fails.
+     * @param onAlerts Callback invoked when alerts are fetched.
+     * @param onAirQuality Callback invoked when air quality data is fetched.
+     */
     suspend operator fun invoke(
         location: Location,
         isManualRefresh: Boolean = false,
         isForceRefresh: Boolean = false,
         isForceRefreshForAirQuality: Boolean = false,
         isForceRefreshForAlerts: Boolean = false,
+        onLocationUpdated: (Location) -> Unit = {},
         onWeather: suspend (WeatherResult, Location) -> Unit,
         onAlerts: suspend (AlertResult?) -> Unit,
         onAirQuality: suspend (AirQualityResult?) -> Unit,
@@ -34,6 +51,7 @@ class GetWeatherUseCase @Inject constructor(
                 effectiveForceRefresh = true
                 effectiveForceRefreshForAirQuality = true
                 effectiveForceRefreshForAlerts = true
+                onLocationUpdated(effectiveLocation)
             }
         }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
@@ -23,6 +23,8 @@ class GetWeatherUseCase @Inject constructor(
      * Cancellation of the calling coroutine will correctly cancel all internal
      * asynchronous operations.
      *
+     * All callbacks are invoked on the dispatcher used by the caller.
+     *
      * @param location The location to fetch data for.
      * @param isManualRefresh Whether this is a user-initiated refresh (e.g., pull-to-refresh).
      * @param isForceRefresh Whether to bypass caches for weather data.
@@ -39,7 +41,7 @@ class GetWeatherUseCase @Inject constructor(
         isForceRefresh: Boolean = false,
         isForceRefreshForAirQuality: Boolean = false,
         isForceRefreshForAlerts: Boolean = false,
-        onLocationUpdated: (Location) -> Unit = {},
+        onLocationUpdated: suspend (Location) -> Unit = {},
         onWeather: suspend (WeatherResult, Location) -> Unit,
         onAlerts: suspend (AlertResult?) -> Unit,
         onAirQuality: suspend (AirQualityResult?) -> Unit,

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
@@ -24,6 +24,8 @@ class GetWeatherUseCase @Inject constructor(
      * asynchronous operations.
      *
      * All callbacks are invoked on the dispatcher used by the caller.
+     * Note: [onWeather], [onAlerts], and [onAirQuality] may be invoked from the
+     * repository's dispatcher if not explicitly controlled by the caller.
      *
      * @param location The location to fetch data for.
      * @param isManualRefresh Whether this is a user-initiated refresh (e.g., pull-to-refresh).

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
@@ -18,6 +18,11 @@ class GetWeatherUseCase @Inject constructor(
     /**
      * Executes the weather fetch process.
      *
+     * This function should be called from a coroutine scope (e.g., [viewModelScope]).
+     * It handles internal suspension and parallel execution of data fetching.
+     * Cancellation of the calling coroutine will correctly cancel all internal
+     * asynchronous operations.
+     *
      * @param location The location to fetch data for.
      * @param isManualRefresh Whether this is a user-initiated refresh (e.g., pull-to-refresh).
      * @param isForceRefresh Whether to bypass caches for weather data.

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCase.kt
@@ -1,5 +1,9 @@
 package com.pranshulgg.weather_master_app.domain.usecase
 
+/**
+ * Initial Clean Architecture Domain Layer integration implemented by https://github.com/gietabhi10
+ */
+
 import com.pranshulgg.weather_master_app.core.model.domain.location.Location
 import com.pranshulgg.weather_master_app.core.model.weather.WeatherResult
 import com.pranshulgg.weather_master_app.core.model.weather.airquality.AirQualityResult

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/LoadWeatherBlocksUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/LoadWeatherBlocksUseCase.kt
@@ -1,5 +1,9 @@
 package com.pranshulgg.weather_master_app.domain.usecase
 
+/**
+ * Initial Clean Architecture Domain Layer integration implemented by https://github.com/gietabhi10
+ */
+
 import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
 import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
 import javax.inject.Inject

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/LoadWeatherBlocksUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/LoadWeatherBlocksUseCase.kt
@@ -1,0 +1,13 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
+import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
+import javax.inject.Inject
+
+class LoadWeatherBlocksUseCase @Inject constructor(
+    private val weatherBlocksRepository: WeatherBlocksRepository
+) {
+    suspend operator fun invoke(isDaily: Boolean = false): List<WeatherBlock> {
+        return weatherBlocksRepository.loadBlocks(isDaily)
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/LoadWeatherBlocksUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/LoadWeatherBlocksUseCase.kt
@@ -4,6 +4,12 @@ import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
 import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
 import javax.inject.Inject
 
+/**
+ * Use case to load the configured weather blocks (e.g. Humidity, UV Index) for a screen.
+ *
+ * It handles fetching the saved order/visibility from the database and falling back
+ * to defaults if no custom configuration exists.
+ */
 class LoadWeatherBlocksUseCase @Inject constructor(
     private val weatherBlocksRepository: WeatherBlocksRepository
 ) {

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/README.md
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/README.md
@@ -1,0 +1,23 @@
+# Domain Layer: Use Cases
+
+This package contains the business logic of the application, following **Clean Architecture** principles.
+
+## Responsibility Split
+
+### 1. Use Cases (This Package)
+- **What they do**: Orchestrate complex operations that span multiple repositories or involve business-specific rules.
+- **Example**: `GetWeatherUseCase` coordinates location updates with data fetching from weather, alerts, and air quality sources.
+- **Rule**: They should be platform-independent and reusable across different ViewModels.
+
+### 2. ViewModels (`feature/**`)
+- **What they do**: Manage UI state and handle user interactions.
+- **Rule**: They should delegate business logic to Use Cases and focus purely on UI logic (loading states, error handling, mapping data to UI models).
+
+### 3. Repositories (`data/repository/**`)
+- **What they do**: Provide a clean API for data access (Remote vs. Local).
+- **Rule**: They handle data mapping and caching logic but should not contain orchestration logic that involves other feature areas.
+
+## Best Practices
+- **Mocking**: Use Cases should be mocked in ViewModel tests to verify delegation.
+- **Threading**: Use Cases are `suspend` functions and should be called from a coroutine scope (e.g., `viewModelScope`).
+- **Cancellation**: All asynchronous operations within a Use Case should respect the cancellation of the calling coroutine.

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/SaveWeatherBlocksUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/SaveWeatherBlocksUseCase.kt
@@ -4,6 +4,9 @@ import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
 import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
 import javax.inject.Inject
 
+/**
+ * Use case to save the order and visibility configuration of weather blocks to the database.
+ */
 class SaveWeatherBlocksUseCase @Inject constructor(
     private val weatherBlocksRepository: WeatherBlocksRepository
 ) {

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/SaveWeatherBlocksUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/SaveWeatherBlocksUseCase.kt
@@ -1,5 +1,9 @@
 package com.pranshulgg.weather_master_app.domain.usecase
 
+/**
+ * Initial Clean Architecture Domain Layer integration implemented by https://github.com/gietabhi10
+ */
+
 import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
 import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
 import javax.inject.Inject

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/SaveWeatherBlocksUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/SaveWeatherBlocksUseCase.kt
@@ -1,0 +1,13 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
+import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
+import javax.inject.Inject
+
+class SaveWeatherBlocksUseCase @Inject constructor(
+    private val weatherBlocksRepository: WeatherBlocksRepository
+) {
+    suspend operator fun invoke(items: List<WeatherBlock>, isDaily: Boolean = false) {
+        weatherBlocksRepository.saveBlocks(items, isDaily)
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
@@ -1,5 +1,9 @@
 package com.pranshulgg.weather_master_app.domain.usecase
 
+/**
+ * Initial Clean Architecture Domain Layer integration implemented by https://github.com/gietabhi10
+ */
+
 import com.pranshulgg.weather_master_app.core.model.domain.location.Location
 import com.pranshulgg.weather_master_app.core.model.weather.openmeteo.OpenMeteoModel
 import com.pranshulgg.weather_master_app.core.model.sources.Source

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
@@ -17,6 +17,11 @@ class UpdateLocationSourceUseCase @Inject constructor(
     private val locationsRepo: LocationsRepository,
     private val weatherDataReconcilerRepository: WeatherDataReconcilerRepository
 ) {
+    /**
+     * Updates the weather, air quality, and alert sources for a location.
+     *
+     * @return An in-memory copy of the updated [Location].
+     */
     suspend operator fun invoke(
         location: Location,
         source: Source,

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
@@ -1,0 +1,40 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.weather.openmeteo.OpenMeteoModel
+import com.pranshulgg.weather_master_app.core.model.sources.Source
+import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
+import com.pranshulgg.weather_master_app.data.repository.WeatherDataReconcilerRepository
+import javax.inject.Inject
+
+class UpdateLocationSourceUseCase @Inject constructor(
+    private val locationsRepo: LocationsRepository,
+    private val weatherDataReconcilerRepository: WeatherDataReconcilerRepository
+) {
+    suspend operator fun invoke(
+        location: Location,
+        source: Source,
+        airQualitySource: Source,
+        alertSource: Source,
+        openMeteoModel: OpenMeteoModel
+    ): Location {
+        val updatedLocation = location.copy(
+            source = source,
+            airQualitySource = airQualitySource,
+            alertSource = alertSource,
+            openMeteoModel = openMeteoModel
+        )
+
+        locationsRepo.updateSourceForLocation(location.id, source)
+        locationsRepo.updateAirQualitySourceForLocation(location.id, airQualitySource)
+        locationsRepo.updateAlertSourceForLocation(location.id, alertSource)
+        locationsRepo.updateOpenMeteoModelForLocation(location.id, openMeteoModel)
+
+        weatherDataReconcilerRepository.reconcileSourceChange(
+            previous = location,
+            updated = updatedLocation
+        )
+        
+        return updatedLocation
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
@@ -45,8 +45,6 @@ class UpdateLocationSourceUseCase @Inject constructor(
         locationsRepo.updateAlertSourceForLocation(location.id, alertSource)
         locationsRepo.updateOpenMeteoModelForLocation(location.id, openMeteoModel)
 
-        // Reconciliation cleans up stale data from previous sources.
-        // Note: These updates are currently performed in sequence without a transaction.
         weatherDataReconcilerRepository.reconcileSourceChange(
             previous = location,
             updated = updatedLocation

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
@@ -7,6 +7,12 @@ import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
 import com.pranshulgg.weather_master_app.data.repository.WeatherDataReconcilerRepository
 import javax.inject.Inject
 
+/**
+ * Use case to update weather, air quality, and alert sources for a specific location.
+ *
+ * This use case updates the location configuration in the database and triggers
+ * data reconciliation to clean up any stale data associated with previous sources.
+ */
 class UpdateLocationSourceUseCase @Inject constructor(
     private val locationsRepo: LocationsRepository,
     private val weatherDataReconcilerRepository: WeatherDataReconcilerRepository

--- a/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCase.kt
@@ -41,6 +41,8 @@ class UpdateLocationSourceUseCase @Inject constructor(
         locationsRepo.updateAlertSourceForLocation(location.id, alertSource)
         locationsRepo.updateOpenMeteoModelForLocation(location.id, openMeteoModel)
 
+        // Reconciliation cleans up stale data from previous sources.
+        // Note: These updates are currently performed in sequence without a transaction.
         weatherDataReconcilerRepository.reconcileSourceChange(
             previous = location,
             updated = updatedLocation

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/daily/DailyScreenViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/daily/DailyScreenViewModel.kt
@@ -7,8 +7,9 @@ import androidx.lifecycle.viewModelScope
 import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
 import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherUnits
 import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
-import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
 import com.pranshulgg.weather_master_app.data.repository.WeatherUnitsRepository
+import com.pranshulgg.weather_master_app.domain.usecase.LoadWeatherBlocksUseCase
+import com.pranshulgg.weather_master_app.domain.usecase.SaveWeatherBlocksUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -16,8 +17,9 @@ import javax.inject.Inject
 @HiltViewModel
 class DailyScreenViewModel @Inject constructor(
     private val locationsRepo: LocationsRepository,
-    private val weatherBlocksRepository: WeatherBlocksRepository,
-    private val weatherUnitsRepository: WeatherUnitsRepository
+    private val weatherUnitsRepository: WeatherUnitsRepository,
+    private val loadWeatherBlocksUseCase: LoadWeatherBlocksUseCase,
+    private val saveWeatherBlocksUseCase: SaveWeatherBlocksUseCase
 ) : ViewModel() {
 
     private var _uiState = mutableStateOf(DailyScreenUiState())
@@ -39,11 +41,16 @@ class DailyScreenViewModel @Inject constructor(
     }
 
 
-    // TODO: Duplicate from `WeatherViewModel`
     fun loadBlocks() {
         viewModelScope.launch {
-            val loadedBlocks = weatherBlocksRepository.loadBlocks(isDaily = true)
+            val loadedBlocks = loadWeatherBlocksUseCase(isDaily = true)
             _uiState.value = _uiState.value.copy(blocks = loadedBlocks)
+        }
+    }
+
+    fun saveBlocks(blocks: List<WeatherBlock>) {
+        viewModelScope.launch {
+            saveWeatherBlocksUseCase(blocks, isDaily = true)
         }
     }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/MainScreen.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/MainScreen.kt
@@ -167,7 +167,6 @@ fun MainScreen(navController: NavController, weatherViewModel: WeatherViewModel)
                     if (activeLocation != null) {
                         weatherViewModel.getWeather(
                             activeLocation,
-                            activeLocation.source,
                             isManualRefresh = true
                         )
                     }
@@ -201,6 +200,3 @@ fun MainScreen(navController: NavController, weatherViewModel: WeatherViewModel)
         show = mainScreenUiState.isChangelogSheetOpen
     )
 }
-
-
-

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
@@ -22,11 +22,13 @@ import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResult
 import com.pranshulgg.weather_master_app.core.model.weather.openmeteo.OpenMeteoModel
 import com.pranshulgg.weather_master_app.core.ui.snackbar.SnackbarManager
 import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
-import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
-import com.pranshulgg.weather_master_app.data.repository.WeatherDataReconcilerRepository
 import com.pranshulgg.weather_master_app.data.repository.WeatherUnitsRepository
-import com.pranshulgg.weather_master_app.data.repository.data.SourceDataRepository
-import com.pranshulgg.weather_master_app.data.worker.WeatherBackgroundUpdateScheduler
+import com.pranshulgg.weather_master_app.data.worker.WeatherUpdateScheduler
+import com.pranshulgg.weather_master_app.domain.usecase.DeleteLocationUseCase
+import com.pranshulgg.weather_master_app.domain.usecase.GetWeatherUseCase
+import com.pranshulgg.weather_master_app.domain.usecase.LoadWeatherBlocksUseCase
+import com.pranshulgg.weather_master_app.domain.usecase.SaveWeatherBlocksUseCase
+import com.pranshulgg.weather_master_app.domain.usecase.UpdateLocationSourceUseCase
 import com.pranshulgg.weather_master_app.feature.main.MainScreenWeatherUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -46,9 +48,11 @@ import kotlin.time.Duration.Companion.minutes
 class WeatherViewModel @Inject constructor(
     private val locationsRepo: LocationsRepository,
     appWeatherUnitsRepo: WeatherUnitsRepository,
-    private val weatherBlocksRepository: WeatherBlocksRepository,
-    private val weatherDataReconcilerRepository: WeatherDataReconcilerRepository,
-    private val sourceDataRepository: SourceDataRepository,
+    private val getWeatherUseCase: GetWeatherUseCase,
+    private val deleteLocationUseCase: DeleteLocationUseCase,
+    private val updateLocationSourceUseCase: UpdateLocationSourceUseCase,
+    private val loadWeatherBlocksUseCase: LoadWeatherBlocksUseCase,
+    private val saveWeatherBlocksUseCase: SaveWeatherBlocksUseCase,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -64,10 +68,10 @@ class WeatherViewModel @Inject constructor(
     private val processLifecycleObserver = object : DefaultLifecycleObserver {
         override fun onStart(owner: LifecycleOwner) {
             val location = _uiState.value.activeLocation ?: return
-            startAutoRefresh(location = location, source = location.source)
+            startAutoRefresh(location = location)
             // isInitialized guard avoids duplicating setActiveLocation()'s cold-start fetch.
             if (_uiState.value.isInitialized) {
-                getWeather(location = location, source = location.source)
+                getWeather(location = location)
             }
         }
 
@@ -130,7 +134,6 @@ class WeatherViewModel @Inject constructor(
 
     fun getWeather(
         location: Location,
-        source: Source,
         isManualRefresh: Boolean = false,
         isForceRefresh: Boolean = false,
         isForceRefreshForAirQuality: Boolean = false,
@@ -148,35 +151,16 @@ class WeatherViewModel @Inject constructor(
 
         weatherJob = viewModelScope.launch {
 
-            var effectiveLocation = location
-            var effectiveForceRefresh = isForceRefresh
-            var effectiveForceRefreshForAirQuality = isForceRefreshForAirQuality
-            var effectiveForceRefreshForAlerts = isForceRefreshForAlerts
-
-            // Checked regardless of isManualRefresh so it also runs on app-open/auto-refresh,
-            // not just pull-to-refresh. If the device actually moved, force a real fetch for
-            // the new coordinates instead of trusting a cache keyed to the old ones (note:
-            // isForceRefresh bypasses the cache unconditionally, unlike isManualRefresh, which
-            // only relaxes the cache TTL and would still be blocked by the 15-min throttle).
-            if (location.isDeviceLocation) {
-                val positionChanged = handleDeviceLocation()
-                if (positionChanged) {
-                    effectiveLocation = locationsRepo.getLocationForId(location.id)
-                    effectiveForceRefresh = true
-                    effectiveForceRefreshForAirQuality = true
-                    effectiveForceRefreshForAlerts = true
-                    _uiState.value = _uiState.value.copy(activeLocation = effectiveLocation)
-                }
-            }
-
-
-            sourceDataRepository.getData(
-                location = effectiveLocation,
+            getWeatherUseCase(
+                location = location,
                 isManualRefresh = isManualRefresh,
-                isForceRefresh = effectiveForceRefresh,
-                isForceRefreshForAirQuality = effectiveForceRefreshForAirQuality,
-                isForceRefreshForAlerts = effectiveForceRefreshForAlerts,
-                onWeather = { result ->
+                isForceRefresh = isForceRefresh,
+                isForceRefreshForAirQuality = isForceRefreshForAirQuality,
+                isForceRefreshForAlerts = isForceRefreshForAlerts,
+                onLocationUpdated = { updatedLocation ->
+                    _uiState.value = _uiState.value.copy(activeLocation = updatedLocation)
+                },
+                onWeather = { result, effectiveLocation ->
                     handleWeatherData(result, effectiveLocation)
                 },
                 onAlerts = { result ->
@@ -186,34 +170,6 @@ class WeatherViewModel @Inject constructor(
                     handleAirQuality(result)
                 },
             )
-//            handleWeatherData(source, effectiveLocation, isManualRefresh, effectiveForceRefresh)
-
-            // Run separately
-//            if (!_uiState.value.isError) {
-//                launch {
-//                    handleAirQuality(
-//                        effectiveLocation,
-//                        isManualRefresh,
-//                        effectiveForceRefreshForAirQuality
-//                    )
-//                }
-//
-
-            // Only run separately if the alert source is a different API of its own
-            // If not, then run after the weather has fetched
-//                if (!source.providesAlerts && effectiveLocation.alertSource.name != source.name) {
-//                    launch {
-//                        handleAlerts(
-//                            effectiveLocation,
-//                            isManualRefresh,
-//                            effectiveForceRefreshForAlerts
-//                        )
-//                    }
-//                } else {
-//                    handleAlertsFromWeatherSource(effectiveLocation)
-//                }
-//            }
-
 
             val elapsed = System.currentTimeMillis() - startTime
             val minLoadingTime = 1000L // 1s
@@ -234,7 +190,7 @@ class WeatherViewModel @Inject constructor(
 
     fun deleteLocation(id: String) {
         viewModelScope.launch {
-            locationsRepo.deleteLocation(id)
+            deleteLocationUseCase(id)
 
             if (_uiState.value.activeLocation?.id == id) {
                 setActiveLocation(_uiState.value.locations.first { it.isDefault })
@@ -249,7 +205,7 @@ class WeatherViewModel @Inject constructor(
 
     fun setActiveLocation(location: Location) {
         _uiState.value = _uiState.value.copy(activeLocation = location)
-        getWeather(location, location.source)
+        getWeather(location)
     }
 
 
@@ -260,33 +216,24 @@ class WeatherViewModel @Inject constructor(
         alertSource: Source,
         openMeteoModel: OpenMeteoModel
     ) {
-        val updatedLocation = location.copy(
-            source = source,
-            airQualitySource = airQualitySource,
-            alertSource = alertSource,
-            openMeteoModel = openMeteoModel
-        )
-
         viewModelScope.launch {
 
-            locationsRepo.updateSourceForLocation(location.id, source)
-            locationsRepo.updateAirQualitySourceForLocation(location.id, airQualitySource)
-            locationsRepo.updateAlertSourceForLocation(location.id, alertSource)
-            locationsRepo.updateOpenMeteoModelForLocation(location.id, openMeteoModel)
+            val updatedLocation = updateLocationSourceUseCase(
+                location = location,
+                source = source,
+                airQualitySource = airQualitySource,
+                alertSource = alertSource,
+                openMeteoModel = openMeteoModel
+            )
 
             val allowForceRefreshForWeather =
                 location.source != source || location.openMeteoModel != openMeteoModel
             val allowForceRefreshForAirQuality = location.airQualitySource != airQualitySource
             val allowForceRefreshForAlerts = location.alertSource != alertSource
 
-            weatherDataReconcilerRepository.reconcileSourceChange(
-                previous = location,
-                updated = updatedLocation
-            )
             _uiState.value = _uiState.value.copy(activeLocation = updatedLocation)
             getWeather(
                 updatedLocation,
-                source,
                 isForceRefresh = allowForceRefreshForWeather,
                 isForceRefreshForAirQuality = allowForceRefreshForAirQuality,
                 isForceRefreshForAlerts = allowForceRefreshForAlerts
@@ -301,15 +248,7 @@ class WeatherViewModel @Inject constructor(
     ) {
 
         viewModelScope.launch {
-            weatherBlocksRepository.saveBlocks(items.map {
-                WeatherBlock(
-                    type = it.type,
-                    isHidden = false,
-                    position = it.position,
-                    isDaily = isDaily,
-                    id = it.id
-                )
-            }, isDaily)
+            saveWeatherBlocksUseCase(items, isDaily)
 
         }
         _uiState.value = _uiState.value.copy(blocks = items)
@@ -317,13 +256,8 @@ class WeatherViewModel @Inject constructor(
     }
 
     suspend fun loadBlocks() {
-        val loadedBlocks = weatherBlocksRepository.loadBlocks()
+        val loadedBlocks = loadWeatherBlocksUseCase()
         _uiState.value = _uiState.value.copy(blocks = loadedBlocks)
-    }
-
-
-    private suspend fun handleDeviceLocation(): Boolean {
-        return locationsRepo.updateDeviceLocationPosition()
     }
 
     private suspend fun handleWeatherData(result: WeatherResult, location: Location) {
@@ -337,6 +271,8 @@ class WeatherViewModel @Inject constructor(
 
             is WeatherResult.Error -> {
 
+                val appExpectation = result.exception.toAppException()
+                SnackbarManager.show(appExpectation.toMessageRes())
 
                 _uiState.value = _uiState.value.copy(
                     isError = true,
@@ -345,9 +281,6 @@ class WeatherViewModel @Inject constructor(
                         location.countryCode?.uppercase()
                     )
                 )
-
-                val appExpectation = result.exception.toAppException()
-                SnackbarManager.show(appExpectation.toMessageRes())
             }
 
             is WeatherResult.RefreshNotAvailable -> {
@@ -357,7 +290,7 @@ class WeatherViewModel @Inject constructor(
         }
 
         if (location.isDefault && !_uiState.value.isError && _uiState.value.weather != null) {
-            WeatherBackgroundUpdateScheduler.updateAllWidgets(
+            WeatherUpdateScheduler.updateAllWidgets(
                 context,
                 _uiState.value.weather!!,
                 _uiState.value.weatherUnits
@@ -429,8 +362,7 @@ class WeatherViewModel @Inject constructor(
     private var autoRefreshJob: Job? = null
 
     fun startAutoRefresh(
-        location: Location,
-        source: Source
+        location: Location
     ) {
 
         if (autoRefreshJob?.isActive == true) return
@@ -444,8 +376,7 @@ class WeatherViewModel @Inject constructor(
                 }
 
                 getWeather(
-                    location = location,
-                    source = source
+                    location = location
                 )
             }
         }
@@ -457,7 +388,6 @@ class WeatherViewModel @Inject constructor(
     }
 
     override fun onCleared() {
-        super.onCleared()
         ProcessLifecycleOwner.get().lifecycle.removeObserver(processLifecycleObserver)
     }
 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
@@ -59,6 +59,10 @@ class WeatherViewModel @Inject constructor(
     private var _uiState = mutableStateOf(MainScreenWeatherUiState())
     val uiState: State<MainScreenWeatherUiState> = _uiState
 
+    companion object {
+        private val AUTO_REFRESH_INTERVAL = 45.minutes
+    }
+
     // Registered on the process-wide lifecycle (same pattern as AppVisibility) rather than a
     // Compose LocalLifecycleOwner tied to a screen: a screen-scoped observer gets torn down and
     // recreated by ordinary in-app navigation, and Android replays a synthetic ON_START to any
@@ -368,7 +372,7 @@ class WeatherViewModel @Inject constructor(
         autoRefreshJob = viewModelScope.launch {
             while (isActive) {
 
-                delay(45.minutes)
+                delay(AUTO_REFRESH_INTERVAL)
                 val location = _uiState.value.activeLocation ?: continue
 
                 if (_uiState.value.isLoading || _uiState.value.isError) {

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
@@ -23,7 +23,7 @@ import com.pranshulgg.weather_master_app.core.model.weather.openmeteo.OpenMeteoM
 import com.pranshulgg.weather_master_app.core.ui.snackbar.SnackbarManager
 import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
 import com.pranshulgg.weather_master_app.data.repository.WeatherUnitsRepository
-import com.pranshulgg.weather_master_app.data.worker.WeatherUpdateScheduler
+import com.pranshulgg.weather_master_app.data.worker.WeatherBackgroundUpdateScheduler
 import com.pranshulgg.weather_master_app.domain.usecase.DeleteLocationUseCase
 import com.pranshulgg.weather_master_app.domain.usecase.GetWeatherUseCase
 import com.pranshulgg.weather_master_app.domain.usecase.LoadWeatherBlocksUseCase
@@ -294,7 +294,7 @@ class WeatherViewModel @Inject constructor(
         }
 
         if (location.isDefault && !_uiState.value.isError && _uiState.value.weather != null) {
-            WeatherUpdateScheduler.updateAllWidgets(
+            WeatherBackgroundUpdateScheduler.updateAllWidgets(
                 context,
                 _uiState.value.weather!!,
                 _uiState.value.weatherUnits

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
@@ -67,8 +67,8 @@ class WeatherViewModel @Inject constructor(
     // this ViewModel's lifetime, so this observer is only ever added once.
     private val processLifecycleObserver = object : DefaultLifecycleObserver {
         override fun onStart(owner: LifecycleOwner) {
+            startAutoRefresh()
             val location = _uiState.value.activeLocation ?: return
-            startAutoRefresh(location = location)
             // isInitialized guard avoids duplicating setActiveLocation()'s cold-start fetch.
             if (_uiState.value.isInitialized) {
                 getWeather(location = location)
@@ -361,9 +361,7 @@ class WeatherViewModel @Inject constructor(
 
     private var autoRefreshJob: Job? = null
 
-    fun startAutoRefresh(
-        location: Location
-    ) {
+    fun startAutoRefresh() {
 
         if (autoRefreshJob?.isActive == true) return
 
@@ -371,6 +369,8 @@ class WeatherViewModel @Inject constructor(
             while (isActive) {
 
                 delay(45.minutes)
+                val location = _uiState.value.activeLocation ?: continue
+
                 if (_uiState.value.isLoading || _uiState.value.isError) {
                     continue
                 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModel.kt
@@ -388,6 +388,7 @@ class WeatherViewModel @Inject constructor(
     }
 
     override fun onCleared() {
+        super.onCleared()
         ProcessLifecycleOwner.get().lifecycle.removeObserver(processLifecycleObserver)
     }
 }

--- a/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/DeleteLocationUseCaseTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/DeleteLocationUseCaseTest.kt
@@ -1,0 +1,25 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DeleteLocationUseCaseTest {
+
+    private val repository: LocationsRepository = mockk(relaxed = true)
+    private val useCase = DeleteLocationUseCase(repository)
+
+    @Test
+    fun `invoke should call deleteLocation on repository`() = runTest {
+        // Given
+        val locationId = "test_id"
+
+        // When
+        useCase(locationId)
+
+        // Then
+        coVerify { repository.deleteLocation(locationId) }
+    }
+}

--- a/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
@@ -8,6 +8,7 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -118,14 +119,14 @@ class GetWeatherUseCaseTest {
     }
 
     @Test
-    fun `invoke should bubble up onWeather result`() = runTest {
+    fun `invoke with device location should not update position if not changed`() = runTest {
         // Given
-        val errorResult = WeatherResult.Error(Exception("Network error"), null)
-        var resultPassedToCallback: WeatherResult? = null
-
-        coEvery {
+        val deviceLocation = dummyLocation.copy(isDeviceLocation = true)
+        
+        coEvery { locationsRepo.updateDeviceLocationPosition() } returns false
+        coJustRun {
             sourceDataRepository.getData(
-                location = any(),
+                location = deviceLocation,
                 isManualRefresh = any(),
                 isForceRefresh = any(),
                 isForceRefreshForAirQuality = any(),
@@ -134,9 +135,53 @@ class GetWeatherUseCaseTest {
                 onAlerts = any(),
                 onAirQuality = any()
             )
+        }
+
+        // When
+        useCase(
+            location = deviceLocation,
+            onWeather = { _, _ -> },
+            onAlerts = {},
+            onAirQuality = {}
+        )
+
+        // Then
+        coVerify { locationsRepo.updateDeviceLocationPosition() }
+        coVerify(exactly = 0) { locationsRepo.getLocationForId(any()) }
+        coVerify {
+            sourceDataRepository.getData(
+                location = deviceLocation,
+                isManualRefresh = false,
+                isForceRefresh = false,
+                isForceRefreshForAirQuality = false,
+                isForceRefreshForAlerts = false,
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        }
+    }
+
+    @Test
+    fun `invoke should bubble up onWeather result`() = runTest {
+        // Given
+        val errorResult = WeatherResult.Error(Exception("Network error"), null)
+        var resultPassedToCallback: WeatherResult? = null
+        val onWeatherSlot = slot<suspend (WeatherResult) -> Unit>()
+
+        coEvery {
+            sourceDataRepository.getData(
+                location = any(),
+                isManualRefresh = any(),
+                isForceRefresh = any(),
+                isForceRefreshForAirQuality = any(),
+                isForceRefreshForAlerts = any(),
+                onWeather = capture(onWeatherSlot),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
         } coAnswers {
-            val onWeatherCallback = it.invocation.args[5] as suspend (WeatherResult) -> Unit
-            onWeatherCallback(errorResult)
+            onWeatherSlot.captured(errorResult)
         }
 
         // When

--- a/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
@@ -1,0 +1,116 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherResult
+import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
+import com.pranshulgg.weather_master_app.data.repository.data.SourceDataRepository
+import io.mockk.coEvery
+import io.mockk.coInvoke
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class GetWeatherUseCaseTest {
+
+    private val locationsRepo: LocationsRepository = mockk()
+    private val sourceDataRepository: SourceDataRepository = mockk()
+    private val useCase = GetWeatherUseCase(locationsRepo, sourceDataRepository)
+
+    private val dummyLocation = Location(
+        id = "1",
+        name = "London",
+        latitude = 51.5,
+        longitude = -0.12,
+        country = "UK",
+        timezone = "GMT",
+        countryCode = "GB",
+        state = "",
+        isDefault = true
+    )
+
+    @Test
+    fun `invoke should call sourceDataRepository getData`() = runTest {
+        // Given
+        coEvery {
+            sourceDataRepository.getData(
+                location = dummyLocation,
+                isManualRefresh = any(),
+                isForceRefresh = any(),
+                isForceRefreshForAirQuality = any(),
+                isForceRefreshForAlerts = any(),
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        } returns mockk<Job>()
+
+        // When
+        useCase(
+            location = dummyLocation,
+            onWeather = { _, _ -> },
+            onAlerts = {},
+            onAirQuality = {}
+        )
+
+        // Then
+        coVerify {
+            sourceDataRepository.getData(
+                location = dummyLocation,
+                isManualRefresh = false,
+                isForceRefresh = false,
+                isForceRefreshForAirQuality = false,
+                isForceRefreshForAlerts = false,
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        }
+    }
+
+    @Test
+    fun `invoke with device location should update position if changed`() = runTest {
+        // Given
+        val deviceLocation = dummyLocation.copy(isDeviceLocation = true)
+        val updatedLocation = deviceLocation.copy(latitude = 52.0)
+        
+        coEvery { locationsRepo.updateDeviceLocationPosition() } returns true
+        coEvery { locationsRepo.getLocationForId(deviceLocation.id) } returns updatedLocation
+        coEvery {
+            sourceDataRepository.getData(
+                location = updatedLocation,
+                isManualRefresh = any(),
+                isForceRefresh = any(),
+                isForceRefreshForAirQuality = any(),
+                isForceRefreshForAlerts = any(),
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        } returns mockk<Job>()
+
+        // When
+        useCase(
+            location = deviceLocation,
+            onWeather = { _, _ -> },
+            onAlerts = {},
+            onAirQuality = {}
+        )
+
+        // Then
+        coVerify { locationsRepo.updateDeviceLocationPosition() }
+        coVerify {
+            sourceDataRepository.getData(
+                location = updatedLocation,
+                isManualRefresh = false,
+                isForceRefresh = true,
+                isForceRefreshForAirQuality = true,
+                isForceRefreshForAlerts = true,
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
@@ -1,15 +1,14 @@
 package com.pranshulgg.weather_master_app.domain.usecase
 
 import com.pranshulgg.weather_master_app.core.model.domain.location.Location
-import com.pranshulgg.weather_master_app.core.model.weather.WeatherResult
 import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
 import com.pranshulgg.weather_master_app.data.repository.data.SourceDataRepository
 import io.mockk.coEvery
-import io.mockk.coInvoke
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class GetWeatherUseCaseTest {
@@ -70,10 +69,11 @@ class GetWeatherUseCaseTest {
     }
 
     @Test
-    fun `invoke with device location should update position if changed`() = runTest {
+    fun `invoke with device location should update position and notify if changed`() = runTest {
         // Given
         val deviceLocation = dummyLocation.copy(isDeviceLocation = true)
         val updatedLocation = deviceLocation.copy(latitude = 52.0)
+        var locationPassedToCallback: Location? = null
         
         coEvery { locationsRepo.updateDeviceLocationPosition() } returns true
         coEvery { locationsRepo.getLocationForId(deviceLocation.id) } returns updatedLocation
@@ -93,6 +93,7 @@ class GetWeatherUseCaseTest {
         // When
         useCase(
             location = deviceLocation,
+            onLocationUpdated = { locationPassedToCallback = it },
             onWeather = { _, _ -> },
             onAlerts = {},
             onAirQuality = {}
@@ -100,6 +101,7 @@ class GetWeatherUseCaseTest {
 
         // Then
         coVerify { locationsRepo.updateDeviceLocationPosition() }
+        assertEquals(updatedLocation, locationPassedToCallback)
         coVerify {
             sourceDataRepository.getData(
                 location = updatedLocation,

--- a/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
@@ -1,12 +1,13 @@
 package com.pranshulgg.weather_master_app.domain.usecase
 
 import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherResult
 import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
 import com.pranshulgg.weather_master_app.data.repository.data.SourceDataRepository
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -32,7 +33,7 @@ class GetWeatherUseCaseTest {
     @Test
     fun `invoke should call sourceDataRepository getData`() = runTest {
         // Given
-        coEvery {
+        coJustRun {
             sourceDataRepository.getData(
                 location = dummyLocation,
                 isManualRefresh = any(),
@@ -43,7 +44,7 @@ class GetWeatherUseCaseTest {
                 onAlerts = any(),
                 onAirQuality = any()
             )
-        } returns mockk<Job>()
+        }
 
         // When
         useCase(
@@ -77,7 +78,7 @@ class GetWeatherUseCaseTest {
         
         coEvery { locationsRepo.updateDeviceLocationPosition() } returns true
         coEvery { locationsRepo.getLocationForId(deviceLocation.id) } returns updatedLocation
-        coEvery {
+        coJustRun {
             sourceDataRepository.getData(
                 location = updatedLocation,
                 isManualRefresh = any(),
@@ -88,7 +89,7 @@ class GetWeatherUseCaseTest {
                 onAlerts = any(),
                 onAirQuality = any()
             )
-        } returns mockk<Job>()
+        }
 
         // When
         useCase(
@@ -114,5 +115,39 @@ class GetWeatherUseCaseTest {
                 onAirQuality = any()
             )
         }
+    }
+
+    @Test
+    fun `invoke should bubble up onWeather result`() = runTest {
+        // Given
+        val errorResult = WeatherResult.Error(Exception("Network error"), null)
+        var resultPassedToCallback: WeatherResult? = null
+
+        coEvery {
+            sourceDataRepository.getData(
+                location = any(),
+                isManualRefresh = any(),
+                isForceRefresh = any(),
+                isForceRefreshForAirQuality = any(),
+                isForceRefreshForAlerts = any(),
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        } coAnswers {
+            val onWeatherCallback = it.invocation.args[5] as suspend (WeatherResult) -> Unit
+            onWeatherCallback(errorResult)
+        }
+
+        // When
+        useCase(
+            location = dummyLocation,
+            onWeather = { result, _ -> resultPassedToCallback = result },
+            onAlerts = {},
+            onAirQuality = {}
+        )
+
+        // Then
+        assertEquals(errorResult, resultPassedToCallback)
     }
 }

--- a/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/GetWeatherUseCaseTest.kt
@@ -9,10 +9,14 @@ import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class GetWeatherUseCaseTest {
 
     private val locationsRepo: LocationsRepository = mockk()
@@ -194,5 +198,45 @@ class GetWeatherUseCaseTest {
 
         // Then
         assertEquals(errorResult, resultPassedToCallback)
+    }
+
+    @Test
+    fun `invoke should respect cancellation`() = runTest {
+        // Given
+        var weatherCallbackInvoked = false
+        val onWeatherSlot = slot<suspend (WeatherResult) -> Unit>()
+
+        coEvery {
+            sourceDataRepository.getData(
+                location = any(),
+                isManualRefresh = any(),
+                isForceRefresh = any(),
+                isForceRefreshForAirQuality = any(),
+                isForceRefreshForAlerts = any(),
+                onWeather = capture(onWeatherSlot),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        } coAnswers {
+            kotlinx.coroutines.delay(1000)
+            onWeatherSlot.captured(mockk())
+        }
+
+        // When
+        val job = launch {
+            useCase(
+                location = dummyLocation,
+                onWeather = { _, _ -> weatherCallbackInvoked = true },
+                onAlerts = {},
+                onAirQuality = {}
+            )
+        }
+        
+        advanceTimeBy(500)
+        job.cancel()
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(false, weatherCallbackInvoked)
     }
 }

--- a/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/LoadWeatherBlocksUseCaseTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/LoadWeatherBlocksUseCaseTest.kt
@@ -1,0 +1,46 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlockType
+import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LoadWeatherBlocksUseCaseTest {
+
+    private val repository: WeatherBlocksRepository = mockk()
+    private val useCase = LoadWeatherBlocksUseCase(repository)
+
+    @Test
+    fun `invoke should return blocks from repository`() = runTest {
+        // Given
+        val expectedBlocks = listOf(
+            WeatherBlock(id = 1, isDaily = false, type = WeatherBlockType.HUMIDITY_BLOCK, isHidden = false, position = 0)
+        )
+        coEvery { repository.loadBlocks(false) } returns expectedBlocks
+
+        // When
+        val result = useCase(isDaily = false)
+
+        // Then
+        assertEquals(expectedBlocks, result)
+    }
+
+    @Test
+    fun `invoke with isDaily true should return daily blocks from repository`() = runTest {
+        // Given
+        val expectedBlocks = listOf(
+            WeatherBlock(id = 2, isDaily = true, type = WeatherBlockType.WIND_BLOCK, isHidden = false, position = 0)
+        )
+        coEvery { repository.loadBlocks(true) } returns expectedBlocks
+
+        // When
+        val result = useCase(isDaily = true)
+
+        // Then
+        assertEquals(expectedBlocks, result)
+    }
+}

--- a/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/SaveWeatherBlocksUseCaseTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/SaveWeatherBlocksUseCaseTest.kt
@@ -1,0 +1,43 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlockType
+import com.pranshulgg.weather_master_app.data.repository.WeatherBlocksRepository
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class SaveWeatherBlocksUseCaseTest {
+
+    private val repository: WeatherBlocksRepository = mockk(relaxed = true)
+    private val useCase = SaveWeatherBlocksUseCase(repository)
+
+    @Test
+    fun `invoke should call saveBlocks on repository`() = runTest {
+        // Given
+        val blocks = listOf(
+            WeatherBlock(id = 1, isDaily = false, type = WeatherBlockType.HUMIDITY_BLOCK, isHidden = false, position = 0)
+        )
+
+        // When
+        useCase(blocks, isDaily = false)
+
+        // Then
+        coVerify { repository.saveBlocks(blocks, false) }
+    }
+
+    @Test
+    fun `invoke with isDaily true should call saveBlocks with isDaily true`() = runTest {
+        // Given
+        val blocks = listOf(
+            WeatherBlock(id = 2, isDaily = true, type = WeatherBlockType.WIND_BLOCK, isHidden = false, position = 0)
+        )
+
+        // When
+        useCase(blocks, isDaily = true)
+
+        // Then
+        coVerify { repository.saveBlocks(blocks, true) }
+    }
+}

--- a/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCaseTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/domain/usecase/UpdateLocationSourceUseCaseTest.kt
@@ -1,0 +1,68 @@
+package com.pranshulgg.weather_master_app.domain.usecase
+
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.sources.Source
+import com.pranshulgg.weather_master_app.core.model.weather.openmeteo.OpenMeteoModel
+import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
+import com.pranshulgg.weather_master_app.data.repository.WeatherDataReconcilerRepository
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UpdateLocationSourceUseCaseTest {
+
+    private val locationsRepo: LocationsRepository = mockk(relaxed = true)
+    private val weatherDataReconcilerRepository: WeatherDataReconcilerRepository = mockk(relaxed = true)
+    private val useCase = UpdateLocationSourceUseCase(locationsRepo, weatherDataReconcilerRepository)
+
+    private val dummyLocation = Location(
+        id = "1",
+        name = "London",
+        latitude = 51.5,
+        longitude = -0.12,
+        country = "UK",
+        timezone = "GMT",
+        countryCode = "GB",
+        state = "",
+        isDefault = true,
+        source = Source.OPEN_METEO
+    )
+
+    @Test
+    fun `invoke should update location sources and reconcile data`() = runTest {
+        // Given
+        val newSource = Source.MET_NORWAY
+        val newAirQualitySource = Source.ACCU_WEATHER
+        val newAlertSource = Source.NWS
+        val newModel = OpenMeteoModel.BEST_MATCH
+
+        // When
+        val result = useCase(
+            location = dummyLocation,
+            source = newSource,
+            airQualitySource = newAirQualitySource,
+            alertSource = newAlertSource,
+            openMeteoModel = newModel
+        )
+
+        // Then
+        coVerify { locationsRepo.updateSourceForLocation(dummyLocation.id, newSource) }
+        coVerify { locationsRepo.updateAirQualitySourceForLocation(dummyLocation.id, newAirQualitySource) }
+        coVerify { locationsRepo.updateAlertSourceForLocation(dummyLocation.id, newAlertSource) }
+        coVerify { locationsRepo.updateOpenMeteoModelForLocation(dummyLocation.id, newModel) }
+        
+        coVerify { 
+            weatherDataReconcilerRepository.reconcileSourceChange(
+                previous = dummyLocation,
+                updated = any()
+            ) 
+        }
+        
+        assertEquals(newSource, result.source)
+        assertEquals(newAirQualitySource, result.airQualitySource)
+        assertEquals(newAlertSource, result.alertSource)
+        assertEquals(newModel, result.openMeteoModel)
+    }
+}

--- a/app/src/test/java/com/pranshulgg/weather_master_app/feature/daily/DailyScreenViewModelTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/feature/daily/DailyScreenViewModelTest.kt
@@ -1,0 +1,63 @@
+package com.pranshulgg.weather_master_app.feature.daily
+
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlock
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherBlockType
+import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
+import com.pranshulgg.weather_master_app.data.repository.WeatherUnitsRepository
+import com.pranshulgg.weather_master_app.domain.usecase.LoadWeatherBlocksUseCase
+import com.pranshulgg.weather_master_app.domain.usecase.SaveWeatherBlocksUseCase
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@kotlinx.coroutines.ExperimentalCoroutinesApi
+class DailyScreenViewModelTest {
+
+    private val locationsRepo: LocationsRepository = mockk()
+    private val weatherUnitsRepository: WeatherUnitsRepository = mockk()
+    private val loadWeatherBlocksUseCase: LoadWeatherBlocksUseCase = mockk()
+    private val saveWeatherBlocksUseCase: SaveWeatherBlocksUseCase = mockk()
+
+    private lateinit var viewModel: DailyScreenViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = DailyScreenViewModel(
+            locationsRepo,
+            weatherUnitsRepository,
+            loadWeatherBlocksUseCase,
+            saveWeatherBlocksUseCase
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `saveBlocks should call saveWeatherBlocksUseCase with isDaily true`() = runTest {
+        // Given
+        val blocks = listOf(
+            WeatherBlock(id = 1, isDaily = true, type = WeatherBlockType.HUMIDITY_BLOCK, isHidden = false, position = 0)
+        )
+        coJustRun { saveWeatherBlocksUseCase(blocks, true) }
+
+        // When
+        viewModel.saveBlocks(blocks)
+
+        // Then
+        coVerify { saveWeatherBlocksUseCase(blocks, true) }
+    }
+}

--- a/app/src/test/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModelTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModelTest.kt
@@ -1,0 +1,107 @@
+package com.pranshulgg.weather_master_app.feature.shared
+
+import android.content.Context
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherUnits
+import com.pranshulgg.weather_master_app.data.repository.LocationsRepository
+import com.pranshulgg.weather_master_app.data.repository.WeatherUnitsRepository
+import com.pranshulgg.weather_master_app.domain.usecase.*
+import io.mockk.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class WeatherViewModelTest {
+
+    private val locationsRepo: LocationsRepository = mockk()
+    private val appWeatherUnitsRepo: WeatherUnitsRepository = mockk()
+    private val getWeatherUseCase: GetWeatherUseCase = mockk()
+    private val deleteLocationUseCase: DeleteLocationUseCase = mockk()
+    private val updateLocationSourceUseCase: UpdateLocationSourceUseCase = mockk()
+    private val loadWeatherBlocksUseCase: LoadWeatherBlocksUseCase = mockk()
+    private val saveWeatherBlocksUseCase: SaveWeatherBlocksUseCase = mockk()
+    private val context: Context = mockk()
+
+    private lateinit var viewModel: WeatherViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val dummyLocation = Location(
+        id = "1",
+        name = "London",
+        latitude = 51.5,
+        longitude = -0.12,
+        country = "UK",
+        timezone = "GMT",
+        countryCode = "GB",
+        state = "",
+        isDefault = true
+    )
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        
+        every { locationsRepo.getLocations() } returns flowOf(emptyList())
+        every { appWeatherUnitsRepo.getUnits() } returns flowOf(WeatherUnits.getDefault())
+        every { locationsRepo.getDefaultLocation() } returns flowOf(dummyLocation)
+        coEvery { locationsRepo.isLocationsEmpty() } returns false
+        coEvery { loadWeatherBlocksUseCase() } returns emptyList()
+        coJustRun { getWeatherUseCase(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+
+        viewModel = WeatherViewModel(
+            locationsRepo,
+            appWeatherUnitsRepo,
+            getWeatherUseCase,
+            deleteLocationUseCase,
+            updateLocationSourceUseCase,
+            loadWeatherBlocksUseCase,
+            saveWeatherBlocksUseCase,
+            context
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `setActiveLocation should call getWeatherUseCase`() = runTest {
+        // When
+        viewModel.setActiveLocation(dummyLocation)
+        advanceUntilIdle()
+
+        // Then
+        coVerify {
+            getWeatherUseCase(
+                location = dummyLocation,
+                isManualRefresh = false,
+                isForceRefresh = false,
+                isForceRefreshForAirQuality = false,
+                isForceRefreshForAlerts = false,
+                onLocationUpdated = any(),
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        }
+    }
+
+    @Test
+    fun `deleteLocation should call deleteLocationUseCase`() = runTest {
+        // Given
+        coJustRun { deleteLocationUseCase(any()) }
+
+        // When
+        viewModel.deleteLocation("1")
+        advanceUntilIdle()
+
+        // Then
+        coVerify { deleteLocationUseCase("1") }
+    }
+}

--- a/app/src/test/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModelTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.*
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -51,7 +52,19 @@ class WeatherViewModelTest {
         every { locationsRepo.getDefaultLocation() } returns flowOf(dummyLocation)
         coEvery { locationsRepo.isLocationsEmpty() } returns false
         coEvery { loadWeatherBlocksUseCase() } returns emptyList()
-        coJustRun { getWeatherUseCase(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        coJustRun {
+            getWeatherUseCase(
+                location = any(),
+                isManualRefresh = any(),
+                isForceRefresh = any(),
+                isForceRefreshForAirQuality = any(),
+                isForceRefreshForAlerts = any(),
+                onLocationUpdated = any(),
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        }
 
         viewModel = WeatherViewModel(
             locationsRepo,
@@ -103,5 +116,36 @@ class WeatherViewModelTest {
 
         // Then
         coVerify { deleteLocationUseCase("1") }
+    }
+
+    @Test
+    fun `device location update should update activeLocation in state`() = runTest {
+        // Given
+        val deviceLocation = dummyLocation.copy(isDeviceLocation = true)
+        val updatedLocation = deviceLocation.copy(latitude = 52.0)
+        val onLocationUpdatedSlot = slot<(Location) -> Unit>()
+        
+        coEvery {
+            getWeatherUseCase(
+                location = any(),
+                isManualRefresh = any(),
+                isForceRefresh = any(),
+                isForceRefreshForAirQuality = any(),
+                isForceRefreshForAlerts = any(),
+                onLocationUpdated = capture(onLocationUpdatedSlot),
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        } coAnswers {
+            onLocationUpdatedSlot.captured(updatedLocation)
+        }
+
+        // When
+        viewModel.setActiveLocation(deviceLocation)
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(updatedLocation, viewModel.uiState.value.activeLocation)
     }
 }

--- a/app/src/test/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModelTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModelTest.kt
@@ -148,4 +148,45 @@ class WeatherViewModelTest {
         // Then
         assertEquals(updatedLocation, viewModel.uiState.value.activeLocation)
     }
+
+    @Test
+    fun `handleSourceChangeForWeather should compute force refresh flags correctly`() = runTest {
+        // Given
+        val newSource = com.pranshulgg.weather_master_app.core.model.sources.Source.MET_NORWAY
+        val updatedLocation = dummyLocation.copy(source = newSource)
+        
+        coEvery { 
+            updateLocationSourceUseCase(
+                location = any(),
+                source = any(),
+                airQualitySource = any(),
+                alertSource = any(),
+                openMeteoModel = any()
+            ) 
+        } returns updatedLocation
+
+        // When
+        viewModel.handleSourceChangeForWeather(
+            location = dummyLocation,
+            source = newSource,
+            airQualitySource = dummyLocation.airQualitySource,
+            alertSource = dummyLocation.alertSource,
+            openMeteoModel = dummyLocation.openMeteoModel
+        )
+        advanceUntilIdle()
+
+        // Then
+        coVerify {
+            getWeatherUseCase(
+                location = updatedLocation,
+                isForceRefresh = true, // Source changed
+                isForceRefreshForAirQuality = false,
+                isForceRefreshForAlerts = false,
+                onLocationUpdated = any(),
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        }
+    }
 }

--- a/app/src/test/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModelTest.kt
+++ b/app/src/test/java/com/pranshulgg/weather_master_app/feature/shared/WeatherViewModelTest.kt
@@ -14,6 +14,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import kotlin.time.Duration.Companion.minutes
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class WeatherViewModelTest {
@@ -123,7 +124,7 @@ class WeatherViewModelTest {
         // Given
         val deviceLocation = dummyLocation.copy(isDeviceLocation = true)
         val updatedLocation = deviceLocation.copy(latitude = 52.0)
-        val onLocationUpdatedSlot = slot<(Location) -> Unit>()
+        val onLocationUpdatedSlot = slot<suspend (Location) -> Unit>()
         
         coEvery {
             getWeatherUseCase(
@@ -147,6 +148,34 @@ class WeatherViewModelTest {
 
         // Then
         assertEquals(updatedLocation, viewModel.uiState.value.activeLocation)
+    }
+
+    @Test
+    fun `auto refresh should call getWeather periodically`() = runTest {
+        // Given
+        viewModel.setActiveLocation(dummyLocation)
+        advanceUntilIdle()
+        
+        // Clear initial call from setActiveLocation
+        clearMocks(getWeatherUseCase, answers = false)
+
+        // When
+        advanceTimeBy(45.minutes.inWholeMilliseconds + 1)
+
+        // Then
+        coVerify {
+            getWeatherUseCase(
+                location = dummyLocation,
+                isManualRefresh = false,
+                isForceRefresh = false,
+                isForceRefreshForAirQuality = false,
+                isForceRefreshForAlerts = false,
+                onLocationUpdated = any(),
+                onWeather = any(),
+                onAlerts = any(),
+                onAirQuality = any()
+            )
+        }
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,8 @@ hiltWork = "1.4.0"
 hiltCompiler = "1.4.0"
 lifecycleProcess = "2.11.0"
 kotlinMetadataJvm = "2.4.0"
+mockk = "1.14.11"
+turbine = "1.2.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -76,8 +78,10 @@ hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltWork" }
 hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltCompiler" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
 hilt-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlinMetadataJvm" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-


### PR DESCRIPTION
🏗️ Architectural Refactor

Issue: **[Feature Request]** Refactor Business Logic to Use Cases and Setup Testing Suite
Problem Statement: The WeatherViewModel has grown to over 450 lines, taking on too many responsibilities including coordinate reconciliation, parallel data fetching orchestration, and layout management. This high coupling makes it difficult to unit test business logic without mocking the entire UI state. Furthermore, layout management logic is currently duplicated between WeatherViewModel and DailyScreenViewModel, making the codebase harder to maintain. There is also no established infrastructure for modern unit testing (MockK, Coroutine testing).

Proposed Solution:
1. Introduce a Domain Layer with focused Use Cases (GetWeatherUseCase, SaveWeatherBlocksUseCase, etc.) to encapsulate business logic.
2. Refactor existing ViewModels to delegate to these Use Cases, removing code duplication and slimming down the ViewModels.
3. Integrate MockK, Turbine, and kotlinx-coroutines-test into the build configuration.
4. Establish a baseline of unit tests for the new Use Cases to ensure reliability.

Alternatives Considered:
Keeping logic in Repositories: Rejected because complex orchestration (like coordinate updates combined with weather fetching) belongs in a Use Case to keep repositories focused on data mapping.

Hilt-only testing: Rejected in favor of pure unit tests for the domain layer for faster execution.
Acknowledgements:
[x] I have searched the existing issues.
[x] I understand that submitting a request does not guarantee it will be implemented.
[x] I have provided all necessary information.