### PR TITLE
Add MGM (Turkey) weather source

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/di/network/ApiModule.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/di/network/ApiModule.kt
@@ -12,6 +12,7 @@ import com.pranshulgg.weather_master_app.core.network.sources.search.openmeteo.O
 import com.pranshulgg.weather_master_app.core.network.sources.weather.accu.AccuApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.aemet.AemetApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.bmkg.BmkgApi
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.MgmApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.china.ChinaApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.cwa.CwaApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.jma.JmaApi
@@ -108,6 +109,10 @@ object ApiModule {
     @Provides
     @Singleton
     fun provideBmkgApi(): BmkgApi = BmkgApi.create()
+
+    @Provides
+    @Singleton
+    fun provideMgmApi(): MgmApi = MgmApi.create()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/WeatherRepositoryModule.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/WeatherRepositoryModule.kt
@@ -38,6 +38,8 @@ import com.pranshulgg.weather_master_app.core.network.sources.weather.metnorway.
 import com.pranshulgg.weather_master_app.core.network.sources.weather.metnorway.MetNorwayRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.metoffice.MetOfficeApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.metoffice.MetOfficeRepository
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.MgmApi
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.MgmRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.NwsApi
 import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.NwsRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.openmeteo.OpenMeteoApi
@@ -286,4 +288,13 @@ object WeatherRepositoryModule {
         apiKeysDao: ApiKeysDao
     ): OpenWeatherRepository =
         OpenWeatherRepository(dao, weatherDao, api, airQualityDao, apiKeysDao)
+
+    @Provides
+    @Singleton
+    fun provideMgmRepository(
+        dao: LocationsDao,
+        weatherDao: WeatherDao,
+        api: MgmApi,
+        locationKeysDao: LocationKeysDao
+    ): MgmRepository = MgmRepository(dao, weatherDao, api, locationKeysDao)
 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
@@ -198,6 +198,13 @@ enum class Source(
         displayLink = "https://openweathermap.org/",
         capabilities = setOf(Capability.WEATHER, Capability.AIR_QUALITY),
         requiresUserApiKey = true
+    ),
+    MGM(
+        displayName = "MGM",
+        fullName = "Meteoroloji Genel Müdürlüğü",
+        displayLink = "https://www.mgm.gov.tr/",
+        countryNameRes = R.string.country_turkey,
+        capabilities = setOf(Capability.WEATHER)
     );
 
     // Sources that provide snow/rain as precipitation
@@ -238,6 +245,7 @@ private val sourcesByCountry = buildMap {
     put("TW", listOf(Source.CWA))
     put("JP", listOf(Source.JMA))
     put("BR", listOf(Source.INMET))
+    put("TR", listOf(Source.MGM))
 
 }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/MgmApi.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/MgmApi.kt
@@ -1,0 +1,69 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.mgm
+
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmCurrentJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmDailyJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmHourlyResultJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmLocationJson
+import okhttp3.OkHttpClient
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Query
+import java.util.concurrent.TimeUnit
+
+
+interface MgmApi {
+
+    @GET("web/merkezler/lokasyon")
+    suspend fun fetchLocation(
+        @Query("enlem") latitude: Double,
+        @Query("boylam") longitude: Double,
+    ): Response<MgmLocationJson>
+
+    @GET("web/sondurumlar")
+    suspend fun fetchCurrent(
+        @Query("merkezid") stationId: Long,
+    ): Response<List<MgmCurrentJson>>
+
+    @GET("web/tahminler/gunluk")
+    suspend fun fetchDaily(
+        @Query("istno") stationId: Long,
+    ): Response<List<MgmDailyJson>>
+
+    @GET("web/tahminler/saatlik")
+    suspend fun fetchHourly(
+        @Query("istno") stationId: Long,
+    ): Response<List<MgmHourlyResultJson>>
+
+    companion object {
+        const val BASE_URL = "https://servis.mgm.gov.tr/"
+        private const val ORIGIN_URL = "https://www.mgm.gov.tr"
+
+        fun create(): MgmApi {
+
+            val client = OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .addInterceptor { chain ->
+                    // MGM rejects requests without a same-origin Referer/Origin with
+                    // {"error":"ServerError","message":"Not allowed by MGM"} - confirmed live,
+                    // same pattern as BMKG's WAF check (see BmkgApi).
+                    val request = chain.request().newBuilder()
+                        .header("Referer", "$ORIGIN_URL/")
+                        .header("Origin", ORIGIN_URL)
+                        .build()
+
+                    chain.proceed(request)
+                }
+                .build()
+
+            return Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(MgmApi::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/MgmRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/MgmRepository.kt
@@ -1,0 +1,136 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.mgm
+
+import com.pranshulgg.weather_master_app.core.model.domain.AppException
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.domain.toAppException
+import com.pranshulgg.weather_master_app.core.model.sources.Source
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherResult
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherResultType
+import com.pranshulgg.weather_master_app.core.network.calls.safeApiCall
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.bundle.MgmBundle
+import com.pranshulgg.weather_master_app.core.utils.weather.cache.isWeatherCacheSafe
+import com.pranshulgg.weather_master_app.core.utils.weather.cache.shouldReturnWeatherCache
+import com.pranshulgg.weather_master_app.core.utils.weather.forecast.mergeHourlyWeather
+import com.pranshulgg.weather_master_app.data.local.dao.location.LocationKeysDao
+import com.pranshulgg.weather_master_app.data.local.dao.location.LocationsDao
+import com.pranshulgg.weather_master_app.data.local.dao.weather.WeatherDao
+import com.pranshulgg.weather_master_app.data.local.entity.location.LocationKeyEntity
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.mgm.toDomain
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.toCurrentWeatherEntity
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.toDailyWeatherEntity
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.toDomain
+import com.pranshulgg.weather_master_app.data.local.mapper.weather.toHourlyWeatherEntity
+import com.pranshulgg.weather_master_app.data.repository.data.WeatherRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+// The daily-forecast station also serves as the current-conditions station (confirmed live:
+// "merkezId" from the location lookup is what /web/sondurumlar expects, not "sondurumIstNo" -
+// the latter is just informational). Hourly station is separate and can be absent for some
+// rural locations, matching breezy-weather's MGM source.
+private data class MgmStations(val dailyStationId: Long, val hourlyStationId: Long?)
+
+class MgmRepository @Inject constructor(
+    val dao: LocationsDao,
+    val weatherDao: WeatherDao,
+    val api: MgmApi,
+    val locationKeysDao: LocationKeysDao
+) : WeatherRepository {
+
+    override val weatherSource = Source.MGM
+
+    override suspend fun getWeather(
+        location: Location,
+        isManualRefresh: Boolean,
+        isForceRefresh: Boolean
+    ): WeatherResult =
+        withContext(Dispatchers.IO) {
+            val cache = dao.getWeatherDataForLocation(location.id)
+
+            val shouldReturnCache = shouldReturnWeatherCache(cache, isManualRefresh, isForceRefresh)
+            val existingHourly = weatherDao.getHourlyDataForLocation(location.id, location.source)
+
+            when (shouldReturnCache) {
+                WeatherResultType.REFRESH_TOO_EARLY -> return@withContext WeatherResult.RefreshNotAvailable
+                WeatherResultType.SUCCESS -> return@withContext WeatherResult.Success(cache!!.toDomain())
+                else -> {}
+            }
+
+            return@withContext try {
+
+                val stations = locationKeysDao.getCityKeyForLocation(location.id)
+                    ?.cityKey
+                    ?.let { parseStations(it) }
+                    ?: resolveStations(location)
+                    ?: return@withContext WeatherResult.Error(
+                        exception = AppException.EmptyResponseBody()
+                    )
+
+                val current = safeApiCall {
+                    api.fetchCurrent(stations.dailyStationId)
+                }.getOrElse { return@withContext WeatherResult.Error(exception = it.toAppException()) }
+
+                val daily = safeApiCall {
+                    api.fetchDaily(stations.dailyStationId)
+                }.getOrElse { return@withContext WeatherResult.Error(exception = it.toAppException()) }
+
+                val hourly = stations.hourlyStationId?.let { hourlyStationId ->
+                    safeApiCall { api.fetchHourly(hourlyStationId) }.getOrNull()
+                }
+
+                val domain = MgmBundle(
+                    current = current.firstOrNull(),
+                    daily = daily.firstOrNull(),
+                    hourly = hourly?.firstOrNull()?.forecast,
+                ).toDomain(location)
+
+                locationKeysDao.insertCityKey(
+                    LocationKeyEntity(
+                        locationId = location.id,
+                        cityKey = "${stations.dailyStationId}:${stations.hourlyStationId ?: ""}"
+                    )
+                )
+
+                val mergedHourly = mergeHourlyWeather(
+                    existing = existingHourly,
+                    incoming = domain.hourly.toHourlyWeatherEntity(location)
+                )
+                weatherDao.insertWeather(
+                    domain.current.toCurrentWeatherEntity(location.id),
+                    mergedHourly,
+                    domain.daily.toDailyWeatherEntity(location.id),
+                    location.id
+                )
+                WeatherResult.Success(domain)
+
+            } catch (e: Exception) {
+
+                val isCacheSafe = isWeatherCacheSafe(cache)
+
+                WeatherResult.Error(
+                    exception = e,
+                    if (isCacheSafe) cache?.toDomain() else null
+                )
+
+            }
+        }
+
+    private suspend fun resolveStations(location: Location): MgmStations? {
+        val response = safeApiCall {
+            api.fetchLocation(location.latitude, location.longitude)
+        }.getOrNull() ?: return null
+
+        val dailyStationId = response.dailyStationId ?: response.currentStationId ?: return null
+
+        return MgmStations(dailyStationId, response.hourlyStationId)
+    }
+
+    private fun parseStations(cityKey: String): MgmStations? {
+        val parts = cityKey.split(":")
+        val dailyStationId = parts.getOrNull(0)?.toLongOrNull() ?: return null
+        val hourlyStationId = parts.getOrNull(1)?.toLongOrNull()
+
+        return MgmStations(dailyStationId, hourlyStationId)
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/MgmRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/MgmRepository.kt
@@ -31,6 +31,9 @@ import javax.inject.Inject
 // rural locations, matching breezy-weather's MGM source.
 private data class MgmStations(val dailyStationId: Long, val hourlyStationId: Long?)
 
+/**
+ * Initial MGM (Turkey) integration implemented by https://github.com/reveler-hub
+ */
 class MgmRepository @Inject constructor(
     val dao: LocationsDao,
     val weatherDao: WeatherDao,

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/MgmWeatherConditionMap.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/MgmWeatherConditionMap.kt
@@ -1,0 +1,38 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.mgm
+
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherCondition
+
+// Turkish condition codes ("hadise"/"hadiseKodu") cross-checked against breezy-weather's
+// MGM source (github.com/breezy-weather/breezy-weather), which documents the Turkish terms.
+object MgmWeatherConditionMap {
+    fun getCondition(code: String?): WeatherCondition {
+        return when (code) {
+            "A" -> WeatherCondition.CLEAR_SKY // Açık
+            "AB" -> WeatherCondition.MOSTLY_CLEAR // Az Bulutlu
+            "PB" -> WeatherCondition.PARTLY_CLOUDY // Parçalı Bulutlu
+            "CB" -> WeatherCondition.OVERCAST // Çok Bulutlu
+            "HY" -> WeatherCondition.LIGHT_RAIN // Hafif Yağmurlu
+            "Y" -> WeatherCondition.RAIN // Yağmurlu
+            "KY" -> WeatherCondition.HEAVY_RAIN // Kuvvetli Yağmurlu
+            "KKY" -> WeatherCondition.SLEET // Karla Karışık Yağmurlu
+            "HKY" -> WeatherCondition.LIGHT_SNOW // Hafif Kar Yağışlı
+            "K" -> WeatherCondition.SNOW // Kar Yağışlı
+            "KYK", "YKY" -> WeatherCondition.HEAVY_SNOW // Yoğun Kar Yağışlı
+            "HSY" -> WeatherCondition.LIGHT_RAIN // Hafif Sağanak Yağışlı
+            "SY" -> WeatherCondition.RAIN // Sağanak Yağışlı
+            "KSY" -> WeatherCondition.HEAVY_RAIN // Kuvvetli Sağanak Yağışlı
+            "MSY" -> WeatherCondition.RAIN // Mevzi Sağanak Yağışlı
+            "DY" -> WeatherCondition.HAIL // Dolu
+            "GSY" -> WeatherCondition.THUNDERSTORM // Gökgürültülü Sağanak Yağışlı
+            "KGY" -> WeatherCondition.THUNDERSTORM // Kuvvetli Gökgürültülü Sağanak Yağışlı
+            "SIS" -> WeatherCondition.FOG_HAZE // Sisli
+            "PUS" -> WeatherCondition.FOG_HAZE // Puslu
+            "DNM" -> WeatherCondition.FOG_HAZE // Dumanlı
+            "KF" -> WeatherCondition.FOG_HAZE // Toz veya Kum Fırtınası
+            "HHY" -> WeatherCondition.RAIN // Yağışlı
+            // Wind-only descriptors (R/GKR/KKR) and temperature-only ones (SCK/SGK - hot/cold)
+            // don't correspond to a sky condition in this app's model.
+            else -> WeatherCondition.NO_CONDITION_FOUND
+        }
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/MgmCurrentJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/MgmCurrentJson.kt
@@ -1,0 +1,15 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json
+
+import com.google.gson.annotations.SerializedName
+
+data class MgmCurrentJson(
+    @SerializedName("hadiseKodu") val condition: String?,
+    @SerializedName("sicaklik") val temperature: Double?,
+    @SerializedName("hissedilenSicaklik") val feelsLike: Double?,
+    @SerializedName("nem") val humidity: Double?,
+    @SerializedName("ruzgarHiz") val windSpeed: Double?,
+    @SerializedName("ruzgarYon") val windDirection: Double?,
+    @SerializedName("denizeIndirgenmisBasinc") val pressureMsl: Double?,
+    @SerializedName("gorus") val visibility: Double?,
+    @SerializedName("veriZamani") val time: String?,
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/MgmDailyJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/MgmDailyJson.kt
@@ -1,0 +1,50 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json
+
+import com.google.gson.annotations.SerializedName
+
+// MGM returns "Gun0" as a duplicate of "Gun1" (same date, same values) rather than a distinct
+// 6th day - confirmed live. The 5 distinct forecast days are Gun1..Gun5, so Gun0 is skipped here.
+data class MgmDailyJson(
+    @SerializedName("enDusukGun1") val minTempDay1: Double?,
+    @SerializedName("enDusukGun2") val minTempDay2: Double?,
+    @SerializedName("enDusukGun3") val minTempDay3: Double?,
+    @SerializedName("enDusukGun4") val minTempDay4: Double?,
+    @SerializedName("enDusukGun5") val minTempDay5: Double?,
+    @SerializedName("enYuksekGun1") val maxTempDay1: Double?,
+    @SerializedName("enYuksekGun2") val maxTempDay2: Double?,
+    @SerializedName("enYuksekGun3") val maxTempDay3: Double?,
+    @SerializedName("enYuksekGun4") val maxTempDay4: Double?,
+    @SerializedName("enYuksekGun5") val maxTempDay5: Double?,
+    @SerializedName("enDusukNemGun1") val minHumidityDay1: Double?,
+    @SerializedName("enDusukNemGun2") val minHumidityDay2: Double?,
+    @SerializedName("enDusukNemGun3") val minHumidityDay3: Double?,
+    @SerializedName("enDusukNemGun4") val minHumidityDay4: Double?,
+    @SerializedName("enDusukNemGun5") val minHumidityDay5: Double?,
+    @SerializedName("enYuksekNemGun1") val maxHumidityDay1: Double?,
+    @SerializedName("enYuksekNemGun2") val maxHumidityDay2: Double?,
+    @SerializedName("enYuksekNemGun3") val maxHumidityDay3: Double?,
+    @SerializedName("enYuksekNemGun4") val maxHumidityDay4: Double?,
+    @SerializedName("enYuksekNemGun5") val maxHumidityDay5: Double?,
+    @SerializedName("hadiseGun1") val conditionDay1: String?,
+    @SerializedName("hadiseGun2") val conditionDay2: String?,
+    @SerializedName("hadiseGun3") val conditionDay3: String?,
+    @SerializedName("hadiseGun4") val conditionDay4: String?,
+    @SerializedName("hadiseGun5") val conditionDay5: String?,
+    @SerializedName("ruzgarHizGun1") val windSpeedDay1: Double?,
+    @SerializedName("ruzgarHizGun2") val windSpeedDay2: Double?,
+    @SerializedName("ruzgarHizGun3") val windSpeedDay3: Double?,
+    @SerializedName("ruzgarHizGun4") val windSpeedDay4: Double?,
+    @SerializedName("ruzgarHizGun5") val windSpeedDay5: Double?,
+    @SerializedName("ruzgarYonGun1") val windDirectionDay1: Double?,
+    @SerializedName("ruzgarYonGun2") val windDirectionDay2: Double?,
+    @SerializedName("ruzgarYonGun3") val windDirectionDay3: Double?,
+    @SerializedName("ruzgarYonGun4") val windDirectionDay4: Double?,
+    @SerializedName("ruzgarYonGun5") val windDirectionDay5: Double?,
+    // NOTE: these carry a 'Z' suffix but are actually Europe/Istanbul local time, not UTC -
+    // confirmed live and matches a note in the breezy-weather MGM source. Parse as local time.
+    @SerializedName("tarihGun1") val dateDay1: String?,
+    @SerializedName("tarihGun2") val dateDay2: String?,
+    @SerializedName("tarihGun3") val dateDay3: String?,
+    @SerializedName("tarihGun4") val dateDay4: String?,
+    @SerializedName("tarihGun5") val dateDay5: String?,
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/MgmHourlyJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/MgmHourlyJson.kt
@@ -1,0 +1,18 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json
+
+import com.google.gson.annotations.SerializedName
+
+data class MgmHourlyResultJson(
+    @SerializedName("tahmin") val forecast: List<MgmHourlyForecastJson>?,
+)
+
+data class MgmHourlyForecastJson(
+    // Carries a 'Z' suffix but is actually Europe/Istanbul local time, not UTC - see MgmDailyJson.
+    @SerializedName("tarih") val time: String?,
+    @SerializedName("hadise") val condition: String?,
+    @SerializedName("sicaklik") val temperature: Double?,
+    @SerializedName("hissedilenSicaklik") val feelsLike: Double?,
+    @SerializedName("nem") val humidity: Double?,
+    @SerializedName("ruzgarYonu") val windDirection: Double?,
+    @SerializedName("ruzgarHizi") val windSpeed: Double?,
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/MgmLocationJson.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/MgmLocationJson.kt
@@ -1,0 +1,9 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json
+
+import com.google.gson.annotations.SerializedName
+
+data class MgmLocationJson(
+    @SerializedName("merkezId") val currentStationId: Long?,
+    @SerializedName("gunlukTahminIstNo") val dailyStationId: Long?,
+    @SerializedName("saatlikTahminIstNo") val hourlyStationId: Long?,
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/bundle/MgmBundle.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/weather/mgm/json/bundle/MgmBundle.kt
@@ -1,0 +1,12 @@
+package com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.bundle
+
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmCurrentJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmDailyJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmHourlyForecastJson
+
+
+data class MgmBundle(
+    val current: MgmCurrentJson?,
+    val daily: MgmDailyJson?,
+    val hourly: List<MgmHourlyForecastJson>?
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/mgm/MgmJsonMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/weather/sources/mgm/MgmJsonMapper.kt
@@ -1,0 +1,220 @@
+package com.pranshulgg.weather_master_app.data.local.mapper.weather.sources.mgm
+
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.domain.weather.Weather
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherCurrent
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherDaily
+import com.pranshulgg.weather_master_app.core.model.domain.weather.WeatherHourly
+import com.pranshulgg.weather_master_app.core.model.astro.MoonPhase
+import com.pranshulgg.weather_master_app.core.model.weather.WeatherCondition
+import com.pranshulgg.weather_master_app.core.model.weather.wind.WindDirection
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.MgmWeatherConditionMap
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmCurrentJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmDailyJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.MgmHourlyForecastJson
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.json.bundle.MgmBundle
+import com.pranshulgg.weather_master_app.core.utils.weather.astronomy.getMoonTimings
+import com.pranshulgg.weather_master_app.core.utils.weather.astronomy.getSunTimings
+import com.pranshulgg.weather_master_app.core.utils.weather.computing.computeDailyWeatherCondition
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+// MGM's timestamps carry a 'Z' suffix but are actually Europe/Istanbul local time, not UTC -
+// confirmed live and matches a documented note in breezy-weather's MGM source. Parse as local
+// time in that zone instead of treating 'Z' as a real UTC offset.
+private val ISTANBUL_ZONE = ZoneId.of("Europe/Istanbul")
+private val MGM_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+
+private fun String.mgmTimestampToMilliseconds(): Long? {
+    return try {
+        LocalDateTime.parse(this, MGM_TIME_FORMATTER)
+            .atZone(ISTANBUL_ZONE)
+            .toInstant()
+            .toEpochMilli()
+    } catch (e: Exception) {
+        null
+    }
+}
+
+// MGM uses -9999 as a "no data" sentinel instead of omitting the field.
+private fun Double?.orNullIfSentinel(): Double? {
+    return this?.takeIf { it > -9000.0 }
+}
+
+fun MgmBundle.toDomain(location: Location): Weather {
+
+    val dailyEntries = daily?.let { toDailyEntries(it) } ?: emptyList()
+    val hourlyEntries = hourly.orEmpty()
+
+    val dailyTimings = dailyEntries.map { it.first }
+
+    val sunTimings = getSunTimings(dailyTimings, location.timezone, location.latitude, location.longitude)
+    val moonTimings = getMoonTimings(dailyTimings, location.timezone, location.latitude, location.longitude)
+
+    return Weather(
+        location = location,
+        current = current?.toDomain() ?: dailyEntries.firstOrNull()?.let { placeholderCurrent(it.first) }
+            ?: placeholderCurrent(System.currentTimeMillis()),
+        hourly = hourlyEntries.mapNotNull { it.toDomain() },
+        daily = dailyEntries.mapIndexed { index, (time, entry) ->
+            entry.toDomain(
+                time = time,
+                sunrise = sunTimings.getOrNull(index)?.sunrise ?: -1L,
+                sunset = sunTimings.getOrNull(index)?.sunset ?: -1L,
+                dawn = sunTimings.getOrNull(index)?.dawn ?: -1L,
+                dusk = sunTimings.getOrNull(index)?.dusk ?: -1L,
+                moonrise = moonTimings.getOrNull(index)?.moonrise ?: -1L,
+                moonset = moonTimings.getOrNull(index)?.moonset ?: -1L,
+                moonPhase = moonTimings.getOrNull(index)?.phase,
+                hourlyForCondition = hourlyEntries,
+            )
+        },
+    )
+}
+
+private fun MgmCurrentJson.toDomain(): WeatherCurrent {
+    return WeatherCurrent(
+        temperature = temperature.orNullIfSentinel(),
+        humidity = humidity.orNullIfSentinel(),
+        windSpeed = windSpeed.orNullIfSentinel(),
+        windDirection = WindDirection.toWindDirectionFromDegrees(windDirection.orNullIfSentinel()?.toInt()),
+        pressureMsl = pressureMsl.orNullIfSentinel(),
+        visibility = visibility.orNullIfSentinel()?.toInt(),
+        cloudCover = null,
+        uvIndex = null,
+        weatherCondition = MgmWeatherConditionMap.getCondition(condition),
+        feelsLike = feelsLike.orNullIfSentinel(),
+        time = time?.mgmTimestampToMilliseconds() ?: System.currentTimeMillis(),
+        dewPoint = null,
+        utcOffsetSeconds = null,
+        lastUpdatedInMilli = System.currentTimeMillis()
+    )
+}
+
+private fun placeholderCurrent(time: Long): WeatherCurrent {
+    return WeatherCurrent(
+        temperature = null,
+        humidity = null,
+        windSpeed = null,
+        windDirection = null,
+        pressureMsl = null,
+        visibility = null,
+        cloudCover = null,
+        uvIndex = null,
+        weatherCondition = WeatherCondition.NO_CONDITION_FOUND,
+        feelsLike = null,
+        time = time,
+        dewPoint = null,
+        utcOffsetSeconds = null,
+        lastUpdatedInMilli = System.currentTimeMillis()
+    )
+}
+
+private fun MgmHourlyForecastJson.toDomain(): WeatherHourly? {
+    val timeMillis = time?.mgmTimestampToMilliseconds() ?: return null
+
+    return WeatherHourly(
+        temperature = temperature.orNullIfSentinel(),
+        windSpeed = windSpeed.orNullIfSentinel(),
+        windDirection = WindDirection.toWindDirectionFromDegrees(windDirection.orNullIfSentinel()?.toInt()),
+        rain = 0.0, // MGM's forecast endpoints don't expose a precipitation amount
+        snowfall = null,
+        uvIndex = null,
+        pressureMsl = null,
+        visibility = null,
+        humidity = humidity.orNullIfSentinel(),
+        dewPoint = null,
+        weatherCondition = MgmWeatherConditionMap.getCondition(condition),
+        time = timeMillis,
+        precipitationProbability = null
+    )
+}
+
+private data class MgmDailyEntry(
+    val minTemp: Double?,
+    val maxTemp: Double?,
+    val windSpeed: Double?,
+    val windDirection: Double?,
+    val humidityMin: Double?,
+    val humidityMax: Double?,
+    val condition: String?,
+) {
+    fun toDomain(
+        time: Long,
+        sunrise: Long,
+        sunset: Long,
+        dawn: Long,
+        dusk: Long,
+        moonrise: Long,
+        moonset: Long,
+        moonPhase: MoonPhase?,
+        hourlyForCondition: List<MgmHourlyForecastJson>,
+    ): WeatherDaily {
+        val humidityAvg = listOfNotNull(humidityMin, humidityMax).takeIf { it.isNotEmpty() }?.average()
+
+        val hourlyConditionsForDay = hourlyForCondition
+            .filter { it.time?.mgmTimestampToMilliseconds()?.let { t -> t >= time && t < time + 86_400_000L } == true }
+            .map { MgmWeatherConditionMap.getCondition(it.condition) }
+
+        val weatherCondition = computeDailyWeatherCondition(
+            hourlyConditionsForDay,
+            MgmWeatherConditionMap.getCondition(condition)
+        )
+
+        return WeatherDaily(
+            temperatureMin = minTemp,
+            temperatureMax = maxTemp,
+            windSpeed = windSpeed,
+            windDirection = WindDirection.toWindDirectionFromDegrees(windDirection?.toInt()),
+            rainSum = 0.0, // MGM's forecast endpoints don't expose a precipitation amount
+            snowfallSum = null,
+            uvIndexMax = null,
+            weatherCondition = weatherCondition,
+            time = time,
+            precipitationProbabilityMax = null,
+            pressureMsl = null,
+            visibility = null,
+            humidity = humidityAvg,
+            dewPoint = null,
+            sunrise = sunrise,
+            sunset = sunset,
+            moonrise = moonrise,
+            moonset = moonset,
+            moonPhase = moonPhase ?: MoonPhase.NEW_MOON,
+            dawn = dawn,
+            dusk = dusk
+        )
+    }
+}
+
+private fun toDailyEntries(daily: MgmDailyJson): List<Pair<Long, MgmDailyEntry>> {
+    val days = listOf(
+        Triple(daily.dateDay1, 0, daily.conditionDay1),
+        Triple(daily.dateDay2, 1, daily.conditionDay2),
+        Triple(daily.dateDay3, 2, daily.conditionDay3),
+        Triple(daily.dateDay4, 3, daily.conditionDay4),
+        Triple(daily.dateDay5, 4, daily.conditionDay5),
+    )
+
+    val minTemps = listOf(daily.minTempDay1, daily.minTempDay2, daily.minTempDay3, daily.minTempDay4, daily.minTempDay5)
+    val maxTemps = listOf(daily.maxTempDay1, daily.maxTempDay2, daily.maxTempDay3, daily.maxTempDay4, daily.maxTempDay5)
+    val windSpeeds = listOf(daily.windSpeedDay1, daily.windSpeedDay2, daily.windSpeedDay3, daily.windSpeedDay4, daily.windSpeedDay5)
+    val windDirections = listOf(daily.windDirectionDay1, daily.windDirectionDay2, daily.windDirectionDay3, daily.windDirectionDay4, daily.windDirectionDay5)
+    val humidityMins = listOf(daily.minHumidityDay1, daily.minHumidityDay2, daily.minHumidityDay3, daily.minHumidityDay4, daily.minHumidityDay5)
+    val humidityMaxs = listOf(daily.maxHumidityDay1, daily.maxHumidityDay2, daily.maxHumidityDay3, daily.maxHumidityDay4, daily.maxHumidityDay5)
+
+    return days.mapNotNull { (date, index, condition) ->
+        val time = date?.mgmTimestampToMilliseconds() ?: return@mapNotNull null
+
+        time to MgmDailyEntry(
+            minTemp = minTemps[index].orNullIfSentinel(),
+            maxTemp = maxTemps[index].orNullIfSentinel(),
+            windSpeed = windSpeeds[index].orNullIfSentinel(),
+            windDirection = windDirections[index].orNullIfSentinel(),
+            humidityMin = humidityMins[index].orNullIfSentinel(),
+            humidityMax = humidityMaxs[index].orNullIfSentinel(),
+            condition = condition,
+        )
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/provider/SourceRepositoryProvider.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/provider/SourceRepositoryProvider.kt
@@ -21,6 +21,7 @@ import com.pranshulgg.weather_master_app.core.network.sources.weather.meteoam.Me
 import com.pranshulgg.weather_master_app.core.network.sources.weather.meteofrance.MeteoFranceRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.metnorway.MetNorwayRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.metoffice.MetOfficeRepository
+import com.pranshulgg.weather_master_app.core.network.sources.weather.mgm.MgmRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.nws.NwsRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.openmeteo.OpenMeteoRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.openweather.OpenWeatherRepository
@@ -54,6 +55,7 @@ class SourceRepositoryProvider @Inject constructor(
     private val jmaRepository: JmaRepository,
     private val inmetRepository: InmetRepository,
     private val openWeatherRepository: OpenWeatherRepository,
+    private val mgmRepository: MgmRepository,
 
     // ALERTS
     private val alertsWeatherApiRepository: AlertsWeatherApiRepository,
@@ -87,7 +89,8 @@ class SourceRepositoryProvider @Inject constructor(
         alertsWeatherApiRepository,
         wmoSevereWeatherRepository,
         fpasRepository,
-        openWeatherRepository
+        openWeatherRepository,
+        mgmRepository
     )
 
     fun getWeatherRepository(source: Source): WeatherRepository {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,6 +441,7 @@
     <string name="country_canada">Canada</string>
     <string name="country_finland">Finland</string>
     <string name="country_indonesia">Indonesia</string>
+    <string name="country_turkey">Turkey</string>
     <string name="country_italy">Italy</string>
     <string name="country_japan">Japan</string>
     <string name="country_portugal">Portugal</string>


### PR DESCRIPTION
Closes #1079.

## What
Adds MGM (Meteoroloji Genel Müdürlüğü) as a weather source for Turkey.

- `servis.mgm.gov.tr` rejects requests without a same-origin `Referer`/`Origin` header (`{"error":"ServerError","message":"Not allowed by MGM"}`) - fixed the same way as BMKG's Cloudflare WAF check (#1056).
- Resolves per-location station IDs via `/web/merkezler/lokasyon?enlem&boylam` (lat/lon based, no manual station database needed), cached in `location_keys` like IPMA does.
- Maps current conditions, 5-day daily forecast, and hourly forecast (`/web/sondurumlar`, `/web/tahminler/gunluk`, `/web/tahminler/saatlik`).
- Condition codes cross-checked against [breezy-weather's MGM source](https://github.com/breezy-weather/breezy-weather/blob/main/app/src/src_nonfreenet/org/breezyweather/sources/mgm/MgmService.kt), which documents the Turkish terms.
- MGM's daily response returns `Gun0` as an exact duplicate of `Gun1` (same date, same values) rather than a distinct day - confirmed live - so the mapper reads `Gun1`-`Gun5` for the real 5 distinct days.
- No precipitation-amount or precipitation-probability field is exposed by MGM's forecast endpoints, so those stay `null`/`0.0`, same situation as several other sources already in the app.

Tested live on-device against real Turkish stations (Istanbul, and a few others while investigating condition codes/API shape).

## AI disclosure
Used Claude (Anthropic) to investigate the API (confirming the Referer/Origin block and the station-resolution/`Gun0` behavior via live requests), and to write and test this implementation. I reviewed the diff and verified the fix on-device before opening this PR.
