### PR TITLE
fix inverted branches in moonrise/moonset pairing fix

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/weather/astronomy/Astronomy.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/weather/astronomy/Astronomy.kt
@@ -89,13 +89,13 @@ fun getMoonTimings(
          */
         val resolveSet =
             if (moonTimes.rise != null && moonTimes.set != null && moonTimes.rise!! > moonTimes.set) {
-                moonTimes.set
-            } else {
                 MoonTimes.compute()
                     .on(date.plusDays(1))
                     .at(lat, lon)
                     .timezone(safeZoneId(zoneId))
                     .execute().set
+            } else {
+                moonTimes.set
             }
 
         MoonTimings(

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/weather/astronomy/Astronomy.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/utils/weather/astronomy/Astronomy.kt
@@ -78,7 +78,7 @@ fun getMoonTimings(
 
 
         /**
-         * Fix mentioned in https://github.com/PranshulGG/WeatherMaster/issues/1077 by @reveler-hub
+         * Moonrise/moonset pairing fix by https://github.com/reveler-hub
          *
          * Since the moon doesn't follow a clean 24 hr cycle, the lib can return a rise and set that don't belong
          * to the same cycle


### PR DESCRIPTION
Closes #1083.

## What

The fix in `0dda08ec2` (#1077) has its two branches swapped.

Intent, per that commit's own comment: when `rise > set` (e.g. rise 13:55, set 01:56 same day), the `set` is a stale leftover from the previous night's cycle and doesn't belong with that day's rise — it should be replaced with the next day's real set.

But the code did the opposite:

```kotlin
if (rise != null && set != null && rise!! > set) {
    moonTimes.set   // kept the stale value as-is
} else {
    MoonTimes.compute().on(date.plusDays(1))...execute().set   // overwrote the already-correct case
}
```

So the actual reversed-pairing case was left unfixed, and the case that was already correct got overwritten with an unrelated next-day value instead. This is the same symptom reported in #1077/#1072/#1076 and now #1083 — the earlier fix didn't change the observable behavior.

Swapped the two branches so `rise > set` fetches the next day's set, and the normal case keeps the same-day set.

## Testing

`./gradlew :app:compileDebugKotlin` compiles clean. Didn't have a live repro handy for #1083 specifically (BMKG/Indonesia), but walked through the branch logic against the exact example in the original fix's comment (rise 13:55 / set 01:56) to confirm the corrected branch now produces the intended pairing.

## AI disclosure

Used Claude (Anthropic) to trace the reported bug back to this file, identify that the two branches were inverted relative to the fix's own stated intent, and to write/verify this diff.
