### PR TITLE
Fix hourly/day-night icon selection using a stale source timestamp instead of real time

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/daily/DailyScreen.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/daily/DailyScreen.kt
@@ -31,6 +31,7 @@ import com.pranshulgg.weather_master_app.core.prefs.LocalAppPrefs
 import com.pranshulgg.weather_master_app.core.ui.components.Gap
 import com.pranshulgg.weather_master_app.core.ui.components.LargeTopBarScaffold
 import com.pranshulgg.weather_master_app.core.ui.components.NavigateUpBtn
+import com.pranshulgg.weather_master_app.core.utils.formatters.getCurrentTimeFor
 import com.pranshulgg.weather_master_app.core.utils.formatters.safeZoneId
 import com.pranshulgg.weather_master_app.feature.daily.ui.DailyDaysHeader
 import com.pranshulgg.weather_master_app.feature.daily.ui.DailyForecastHeroHeader
@@ -117,7 +118,7 @@ fun DailyScreen(
                 HourlyCard(
                     weather,
                     units,
-                    if (selectedIndex != 0) selectedDaily.time else weather.current.time,
+                    if (selectedIndex != 0) selectedDaily.time else getCurrentTimeFor(weather.location.timezone),
                     isDaily = true
                 )
                 WeatherBlocks(

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/components/FroggyContainer.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/components/FroggyContainer.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.pranshulgg.weather_master_app.core.model.domain.weather.Weather
 import com.pranshulgg.weather_master_app.core.model.weather.toFroggy
+import com.pranshulgg.weather_master_app.core.utils.formatters.getCurrentTimeFor
 
 @Composable
 fun FroggyContainer(weather: Weather) {
@@ -16,7 +17,7 @@ fun FroggyContainer(weather: Weather) {
     Image(
         painter = painterResource(
             weather.current.weatherCondition.toFroggy(
-                targetTimeMilli = weather.current.time,
+                targetTimeMilli = getCurrentTimeFor(weather.location.timezone),
                 daily = weather.daily.firstOrNull()
             )
         ),

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/ui/BackgroundGradients.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/ui/BackgroundGradients.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import com.pranshulgg.weather_master_app.core.model.weather.WeatherCondition
 import com.pranshulgg.weather_master_app.core.model.domain.weather.Weather
 import com.pranshulgg.weather_master_app.core.ui.theme.isThemeDark
+import com.pranshulgg.weather_master_app.core.utils.formatters.getCurrentTimeFor
 import com.pranshulgg.weather_master_app.core.utils.weather.cache.isWeatherDomainSafe
 
 data class Background(
@@ -61,7 +62,7 @@ private fun backgroundGradients(weather: Weather?, isDark: Boolean = true): Back
 
 
     val isDay = if (day != null && day.sunrise != null && day.sunset != null) {
-        weather.current.time in day.sunrise..day.sunset
+        getCurrentTimeFor(weather.location.timezone) in day.sunrise..day.sunset
     } else {
         true
     }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/ui/CurrentWeatherCard.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/ui/CurrentWeatherCard.kt
@@ -25,6 +25,7 @@ import com.pranshulgg.weather_master_app.core.model.weather.toLabel
 import com.pranshulgg.weather_master_app.core.ui.components.Gap
 import com.pranshulgg.weather_master_app.core.ui.components.Symbol
 import com.pranshulgg.weather_master_app.core.ui.components.WeatherIconBox
+import com.pranshulgg.weather_master_app.core.utils.formatters.getCurrentTimeFor
 import com.pranshulgg.weather_master_app.core.utils.formatters.getLastUpdatedTimeString
 import kotlin.math.roundToInt
 
@@ -84,7 +85,7 @@ private fun CardRowContent(weather: Weather, units: WeatherUnits, context: Conte
             )
             WeatherIconBox(
                 current.weatherCondition.toIcon(
-                    targetTimeMilli = weather.current.time,
+                    targetTimeMilli = getCurrentTimeFor(weather.location.timezone),
                     daily = weather.daily.firstOrNull()
                 ),
                 size = 42.dp
@@ -188,7 +189,7 @@ fun PixelStyleCurrentWeatherCard(weather: Weather, units: WeatherUnits, context:
         ) {
             WeatherIconBox(
                 current.weatherCondition.toIcon(
-                    targetTimeMilli = weather.current.time,
+                    targetTimeMilli = getCurrentTimeFor(weather.location.timezone),
                     daily = weather.daily.firstOrNull()
                 ),
                 size = 32.dp

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/ui/weatherAnimations/WeatherAnimations.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/main/ui/weatherAnimations/WeatherAnimations.kt
@@ -3,6 +3,7 @@ package com.pranshulgg.weather_master_app.feature.main.ui.weatherAnimations
 import androidx.compose.runtime.Composable
 import com.pranshulgg.weather_master_app.core.model.weather.WeatherCondition
 import com.pranshulgg.weather_master_app.core.model.domain.weather.Weather
+import com.pranshulgg.weather_master_app.core.utils.formatters.getCurrentTimeFor
 
 @Composable
 fun WeatherAnimations(weather: Weather, isFroggyLayout: Boolean) {
@@ -10,7 +11,7 @@ fun WeatherAnimations(weather: Weather, isFroggyLayout: Boolean) {
     val day = weather.daily.firstOrNull()
 
     val isDay = if (day != null && day.sunrise != null && day.sunset != null) {
-        weather.current.time in day.sunrise..day.sunset
+        getCurrentTimeFor(weather.location.timezone) in day.sunrise..day.sunset
     } else {
         true
     }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/notifications/mapper/NotificationWeatherMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/notifications/mapper/NotificationWeatherMapper.kt
@@ -27,11 +27,12 @@ fun notificationWeatherMapper(
 ): NotificationWeatherModel {
 
     val timezone = weather.location.timezone
+    val nowMilli = getCurrentTimeFor(timezone)
 
     val currentCondition = weather.current.weatherCondition.toLabel(applicationContext)
 
     val currentIcon = weather.current.weatherCondition.toIcon(
-        targetTimeMilli = weather.current.time,
+        targetTimeMilli = nowMilli,
         daily = weather.daily.firstOrNull()
     )
 
@@ -58,7 +59,7 @@ fun notificationWeatherMapper(
 
     val hourlyStartIndex = findHourlyIndexForTime(
         weather.hourly.map { it.time },
-        getCurrentTimeFor(timezone)
+        nowMilli
     )
 
     return NotificationWeatherModel(

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/ui/HourlyCard.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/ui/HourlyCard.kt
@@ -33,6 +33,7 @@ import com.pranshulgg.weather_master_app.core.prefs.LocalAppPrefs
 import com.pranshulgg.weather_master_app.core.ui.components.Gap
 import com.pranshulgg.weather_master_app.core.ui.components.WeatherIconBox
 import com.pranshulgg.weather_master_app.core.ui.theme.ShadowElevation
+import com.pranshulgg.weather_master_app.core.utils.formatters.getCurrentTimeFor
 import com.pranshulgg.weather_master_app.core.utils.formatters.to12HourTimeString
 import com.pranshulgg.weather_master_app.core.utils.formatters.to24HourTimeString
 import com.pranshulgg.weather_master_app.core.utils.weather.cache.isWeatherHourlyDomainSafe
@@ -47,7 +48,7 @@ import kotlin.math.roundToInt
 fun HourlyCard(
     weather: Weather,
     units: WeatherUnits,
-    currentMilli: Long = weather.current.time,
+    currentMilli: Long = getCurrentTimeFor(weather.location.timezone),
     isDaily: Boolean = false
 ) {
 


### PR DESCRIPTION
Related to #1095, #1088.

## What

`weather.current.time` is a *source's own reported observation timestamp* (e.g. BMKG's `presentwx` `datetime` field), not the real current time. Sources can lag the real clock by a few minutes - confirmed live against BMKG's endpoint (~10-15 min lag). That's enough to cross an hour boundary near the top of the hour, which several UI call sites used as their "now" anchor:

- `HourlyCard.kt` - which hourly slot gets highlighted as current
- `CurrentWeatherCard.kt`, `FroggyContainer.kt`, `NotificationWeatherMapper.kt` - day/night icon selection
- `BackgroundGradients.kt`, `WeatherAnimations.kt` - day/night background art
- `DailyScreen.kt` - "now" anchor when viewing today's hourly breakdown

A reporter's screenshot on #1095 showed this exactly: device clock at 2:10 PM, but the hourly forecast highlighted 1 PM as current.

Most of the codebase already has the correct pattern for this - `getCurrentTimeFor(zoneId)` (real device time, converted to the location's zone), already used by the widget/notification hourly-index lookups and the JMA/AEMET/CWA/IMD/MetOffice mappers, sun/moon blocks, etc. This PR just brings the handful of remaining call sites in line with that. `NotificationWeatherMapper.kt` was actually inconsistent within itself - it already used `getCurrentTimeFor` for the hourly index but not for the icon a few lines above.

Left alone on purpose: `weather.current.time` usages in the per-metric detail screens (Humidity/Rain/Snow/Wind/etc. under `feature/blocks/screens/`) - those use it to label which timestamp the "current" data point on the chart represents, not to decide what "now" is, so they're a different use case.

## Testing

Reproduced live on an AVD with mock location set to Jakarta, BMKG source: before the fix, with real device time at 2:27 PM the hourly forecast highlighted 13:00; after the fix, at 2:48 PM it correctly highlights 14:00 with fresh values. `./gradlew :app:compileDebugKotlin` and `:app:assembleDebug` both clean.

## AI disclosure

Used Claude (Anthropic) to investigate the reports, trace the root cause across call sites, and implement/verify this fix on-device.
