### PR TITLE
fix(air-quality): use rounded chips in the legend

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/blocks/screens/airquality/AirQualityScreen.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/blocks/screens/airquality/AirQualityScreen.kt
@@ -1,5 +1,6 @@
 package com.pranshulgg.weather_master_app.feature.blocks.screens.airquality
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.WindowInsets
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -85,16 +87,22 @@ fun AirQualityScreen(navController: NavController, index: Int = 0, locationId: S
                     .padding(paddingValues)
         ) {
 
-            FlowRow(modifier = Modifier.padding(16.dp)) {
+            FlowRow(
+                modifier = Modifier.padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+                verticalArrangement = Arrangement.spacedBy(5.dp)
+            ) {
                 AirQualityLevel.entries.forEach { level ->
                     Surface(
-                        color = AirQualityColors.getColors(level)
+                        color = AirQualityColors.getColors(level),
+                        shape = CircleShape
                     ) {
                         Text(
                             level.toName(context),
                             textAlign = TextAlign.Center,
                             color = AirQualityColors.getTextColors(level),
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 5.dp)
+                            style = MaterialTheme.typography.labelLarge,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp)
                         )
                     }
                 }


### PR DESCRIPTION
Closes #1106.

## What's happening

The category legend at the top of the detailed Air Quality screen renders as touching rectangular color blocks. Once the labels wrap, the connected strip breaks across two lines and no longer reads as a continuous AQI scale. It also looks unrelated to the rounded label treatment used elsewhere in WeatherMaster.

The legend uses the default rectangular shape from `Surface`, has no spacing between entries, and relies on the default text style with broad horizontal padding.

## Implementation

- Use the same compact, rounded treatment as the non-interactive alert metadata chips, so this screen follows an existing app pattern.
- Add spacing in both directions to keep wrapped labels visually separate.
- Use `labelLarge` with the alert chip's padding instead of the default text treatment.

The AQI category order, semantic colors, contrast colors, and chart data remain unchanged. The labels are informational, so they remain plain `Surface`s rather than interactive Material filter or assist chips. The change is limited to the legend on the detailed Air Quality screen.

## Testing

- Ran `./gradlew clean assembleDebug` with JDK 21 successfully.
- Installed the debug APK on a Pixel 7 Android 16 API 36 arm64 AVD at 1080 x 2400.
- Loaded live Open-Meteo data for Mendocino County, opened the detailed Air Quality screen, and confirmed that all six categories render with the intended colors, spacing, typography, and wrapping in both light and dark themes.
- Cold-started the app after each theme change and confirmed that all labels remain visible without clipping at 1080 x 2400.
- Confirmed that the hourly AQI and pollutant charts still render below the legend.

I did not verify every translated label. Languages with substantially longer category names may wrap differently. This change preserves the existing AQI foreground and background colors; the existing Moderate and Poor color pairs remain below the WCAG 4.5:1 contrast target for normal-sized text.

## Screenshots

| Current | Dark theme | Light theme |
| --- | --- | --- |
| ![Current legend](https://github.com/user-attachments/assets/00ba466d-7302-4d3c-b7d2-4d55e57fd69c) | ![Updated legend in dark theme](https://github.com/user-attachments/assets/7ca82abf-e16f-44ae-8c31-9ad637e4acf3) | ![Updated legend in light theme](https://github.com/user-attachments/assets/30c513a0-3d9d-476b-a1f0-8bab5a92dbd1) |

## AI disclosure

OpenAI GPT-5.6 Sol through the Codex harness in T3 Code was used to inspect the existing UI patterns, implement the Compose styling change, run the build and emulator checks, and draft this description. I reviewed the diff and rendered result and take responsibility for the submitted change.
