### PR TITLE
feat(widget): add Comfort 2x2 widget - Google Weather style copy

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/worker/widgets/WidgetWeatherMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/worker/widgets/WidgetWeatherMapper.kt
@@ -44,8 +44,12 @@ fun widgetWeatherMapper(
     )
 
 
-    val currentTemperature = TemperatureUnit.CELSIUS.convert(
+val currentTemperature = TemperatureUnit.CELSIUS.convert(
         weather.current.temperature, units.tempUnit
+    )?.roundToInt()
+
+    val currentFeelsLike = TemperatureUnit.CELSIUS.convert(
+        weather.current.feelsLike, units.tempUnit
     )?.roundToInt()
 
 
@@ -119,7 +123,7 @@ fun widgetWeatherMapper(
             )
         }
 
-    val widgetState = WidgetWeather(
+val widgetState = WidgetWeather(
         currentTemp = "${currentTemperature}°",
         hourly = hourly,
         daily = daily,
@@ -129,7 +133,8 @@ fun widgetWeatherMapper(
         currentFrog = currentFrogIcon,
         locationName = weather.location.name,
         summary = daySummary,
-        weatherCondition = weather.current.weatherCondition
+        weatherCondition = weather.current.weatherCondition,
+        feelsLike = "${currentFeelsLike}°"
     )
 
     // Convert to string

--- a/app/src/main/java/com/pranshulgg/weather_master_app/widgets/model/WidgetVariant.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/widgets/model/WidgetVariant.kt
@@ -4,6 +4,7 @@ enum class WidgetVariant(val label: String) {
     LARGE("Large"),
     COMPACT("Compact"),
     SMALL("Small"),
+    COMFORT("Comfort"),
 
 
     // WEATHER 4 - VARIANTS

--- a/app/src/main/java/com/pranshulgg/weather_master_app/widgets/model/WidgetWeather.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/widgets/model/WidgetWeather.kt
@@ -16,7 +16,8 @@ data class WidgetWeather(
     val locationName: String,
     val summary: String,
     val weatherCondition: WeatherCondition,
-    val uvIndex: Int? = null
+    val uvIndex: Int? = null,
+    val feelsLike: String = "--"
 )
 
 @Serializable

--- a/app/src/main/java/com/pranshulgg/weather_master_app/widgets/weather/WeatherWidget.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/widgets/weather/WeatherWidget.kt
@@ -31,6 +31,7 @@ import com.pranshulgg.weather_master_app.widgets.ui.colors.WidgetTheme
 import com.pranshulgg.weather_master_app.widgets.weather.ui.variants.WeatherWidgetCompact
 import com.pranshulgg.weather_master_app.widgets.weather.ui.variants.WeatherWidgetLarge
 import com.pranshulgg.weather_master_app.widgets.weather.ui.variants.WeatherWidgetSmall
+import com.pranshulgg.weather_master_app.widgets.weather.ui.variants.WeatherWidgetComfort
 import kotlinx.serialization.json.Json
 
 
@@ -72,16 +73,18 @@ class WeatherWidget : GlanceAppWidget() {
                     .clickable(actionStartActivity<MainActivity>())
             ) {
 
-                when (config.variant) {
+when (config.variant) {
 
                     WidgetVariant.LARGE -> WeatherWidgetLarge(
                         state,
                         config.hourlyCount,
                         config,
                         widgetColors
+
                     )
 
                     WidgetVariant.COMPACT -> WeatherWidgetCompact(state, widgetColors, config)
+                    WidgetVariant.COMFORT -> WeatherWidgetComfort(state, config, widgetColors)
                     else -> WeatherWidgetSmall(state, config, widgetColors)
                 }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/widgets/weather/ui/WeatherWidgetConfig.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/widgets/weather/ui/WeatherWidgetConfig.kt
@@ -80,7 +80,7 @@ fun WeatherWidgetConfig(onDone: (WidgetConfig) -> Unit = {}) {
     val widgetTextThemeOptions =
         WidgetTextTheme.entries.map { DialogOption(it.toString(), stringResource(it.label)) }
 
-    val variantFiltered = listOf(WidgetVariant.LARGE, WidgetVariant.COMPACT, WidgetVariant.SMALL)
+    val variantFiltered = listOf(WidgetVariant.LARGE, WidgetVariant.COMPACT, WidgetVariant.SMALL, WidgetVariant.COMFORT)
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surfaceContainer
@@ -330,7 +330,14 @@ private fun GlanceWidgetPreview(
             showPrecipitationProbability
         )
 
-        WidgetVariant.COMPACT -> CompactWidgetPreview(
+WidgetVariant.COMPACT -> CompactWidgetPreview(
+            fontSize, iconSize,
+            widgetColor,
+            textColor,
+            textColorSecondary
+        )
+
+        WidgetVariant.COMFORT -> ComfortWidgetPreview(
             fontSize, iconSize,
             widgetColor,
             textColor,
@@ -604,7 +611,7 @@ private fun SmallWidgetPreview(
             verticalArrangement = Arrangement.Center
         ) {
 
-            WeatherIconBox(R.drawable.weather_clear_night, iconSize.dp)
+WeatherIconBox(R.drawable.weather_clear_night, iconSize.dp)
 
             Gap(8.dp)
             Text(
@@ -614,6 +621,78 @@ private fun SmallWidgetPreview(
                 fontWeight = FontWeight.Bold
             )
 
+        }
+    }
+}
+
+@Composable
+private fun ComfortWidgetPreview(
+    fontSize: Float, iconSize: Float,
+    widgetColor: Color,
+    textColor: Color,
+    textColorSecondary: Color,
+) {
+
+    val mainIconSize = 28 * iconSize
+    val tempFontSize = 52 * fontSize
+
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .width(200.dp)
+            .height(200.dp)
+            .background(
+                widgetColor,
+                RoundedCornerShape(ShapeRadius.ExtraLarge)
+            )
+    ) {
+
+        Column(
+            Modifier.padding(18.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                WeatherIconBox(R.drawable.weather_partly_cloudy_day, mainIconSize.dp)
+                Spacer(Modifier.weight(1f))
+                Text(
+                    "Halifax",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = textColor
+                )
+            }
+
+            Gap(8.dp)
+
+            Text(
+                "23°",
+                fontSize = tempFontSize.sp,
+                fontWeight = FontWeight.Bold,
+                color = textColor
+            )
+
+            Spacer(Modifier.weight(1f))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "23°",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = textColor
+                )
+                Gap(8.dp)
+                Text(
+                    "13°",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = textColorSecondary
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/widgets/weather/ui/variants/WeatherWidgetComfort.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/widgets/weather/ui/variants/WeatherWidgetComfort.kt
@@ -1,0 +1,108 @@
+package com.pranshulgg.weather_master_app.widgets.weather.ui.variants
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.layout.width
+import androidx.glance.layout.height
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import com.pranshulgg.weather_master_app.widgets.config.WidgetConfig
+import com.pranshulgg.weather_master_app.widgets.model.WidgetWeather
+import com.pranshulgg.weather_master_app.widgets.ui.ReloadButton
+import com.pranshulgg.weather_master_app.widgets.ui.colors.WidgetColors
+
+@Composable
+fun WeatherWidgetComfort(
+    state: WidgetWeather?, config: WidgetConfig,
+    widgetColors: WidgetColors
+) {
+    val textColor = widgetColors
+        .getTextColor(config.widgetTextTheme, config.widgetTheme)
+        ?: Pair(GlanceTheme.colors.onSurface, null)
+
+    val textColorVariant = widgetColors
+        .getTextVariantColor(config.widgetTextTheme, config.widgetTheme)
+        ?: GlanceTheme.colors.onSurfaceVariant
+
+    if (state != null) {
+        Column(
+            modifier = GlanceModifier.fillMaxSize().padding(18.dp)
+        ) {
+            Row(
+                modifier = GlanceModifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Image(
+                    provider = ImageProvider(state.currentIcon),
+                    contentDescription = null,
+                    modifier = GlanceModifier.size(28.dp)
+                )
+                Spacer(GlanceModifier.defaultWeight())
+                Text(
+                    state.locationName,
+                    style = TextStyle(
+                        color = textColor.first,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium
+                    ),
+                    maxLines = 1
+                )
+            }
+
+            Spacer(GlanceModifier.height(8.dp))
+
+            Text(
+                state.currentTemp,
+                style = TextStyle(
+                    color = textColor.first,
+                    fontSize = 52.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            )
+
+            Spacer(GlanceModifier.defaultWeight())
+
+            val daily = state.daily.firstOrNull()
+            if (daily != null) {
+                Row(
+                    modifier = GlanceModifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        daily.tempMax,
+                        style = TextStyle(
+                            fontSize = 14.sp,
+                            color = textColor.first,
+                            fontWeight = FontWeight.Medium
+                        )
+                    )
+                    Spacer(GlanceModifier.width(8.dp))
+                    Text(
+                        daily.tempMin,
+                        style = TextStyle(
+                            fontSize = 14.sp,
+                            color = textColorVariant,
+                            fontWeight = FontWeight.Medium
+                        )
+                    )
+                }
+            }
+        }
+    } else {
+        ReloadButton()
+    }
+}


### PR DESCRIPTION
- Add WidgetVariant.COMFORT (2x2, home_screen) replicating Google Weather widget
- Create WeatherWidgetComfort composable: top row icon(28dp) left + location right (Halifax-style), large 52sp current temp, bottom min/max (left-aligned), matches screenshot
- Extend WidgetWeather with feelsLike field and map via WidgetWeatherMapper (Celsius -> user unit) for future use
- Wire variant in WeatherWidget provideGlance and auto-update via existing WeatherWorker->WeatherWidgetUpdater flow
- Add Comfort preview and selector in WeatherWidgetConfig
- Reuses WidgetColors/backgroundShape for light/dark/transparent theme parity

Tested: assembleDebug + adb install on Medium_Phone_API_36.1 emulator, widget upd

<img width="193" height="217" alt="Google Pix Weather" src="https://github.com/user-attachments/assets/9c8d437d-0f75-4176-9473-11612e953f23" />
