### PR TITLE
add support for third-party gadgetbridge receivers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -224,7 +224,8 @@
     </application>
 
     <queries>
-        <package android:name="nodomain.freeyourgadget.gadgetbridge" />
-        <package android:name="nodomain.freeyourgadget.gadgetbridge.nightly" />
+        <intent>
+            <action android:name="nodomain.freeyourgadget.gadgetbridge.ACTION_GENERIC_WEATHER" />
+        </intent>
     </queries>
 </manifest>

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/worker/gadgetbridge/GadgetBridge.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/worker/gadgetbridge/GadgetBridge.kt
@@ -1,23 +1,12 @@
 package com.pranshulgg.weather_master_app.data.worker.gadgetbridge
 
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 
 
 fun isGadgetbridgeInstalled(context: Context): Boolean {
-    val pm = context.packageManager
-    val standardPackage = "nodomain.freeyourgadget.gadgetbridge"
-    val nightlyPackage = "nodomain.freeyourgadget.gadgetbridge.nightly"
-
-    return try {
-        pm.getPackageInfo(standardPackage, 0)
-        true
-    } catch (e: PackageManager.NameNotFoundException) {
-        try {
-            pm.getPackageInfo(nightlyPackage, 0)
-            true
-        } catch (e: PackageManager.NameNotFoundException) {
-            false
-        }
-    }
+    return context.packageManager
+        .queryBroadcastReceivers(Intent("nodomain.freeyourgadget.gadgetbridge.ACTION_GENERIC_WEATHER"), PackageManager.GET_RESOLVED_FILTER)
+        .isNotEmpty()
 }

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/worker/gadgetbridge/SendGadgetBridgeWeatherData.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/worker/gadgetbridge/SendGadgetBridgeWeatherData.kt
@@ -2,6 +2,7 @@ package com.pranshulgg.weather_master_app.data.worker.gadgetbridge
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import com.pranshulgg.weather_master_app.core.model.domain.weather.Weather
 import com.pranshulgg.weather_master_app.core.model.weather.WeatherCondition
 import com.pranshulgg.weather_master_app.core.model.weather.toLabel
@@ -53,19 +54,15 @@ fun sendGadgetBridgeWeatherData(context: Context, weather: Weather) {
             put("hourly", hourlyArray)
         }
 
-        val intent = Intent().apply {
-            action = "nodomain.freeyourgadget.gadgetbridge.ACTION_GENERIC_WEATHER"
-            setClassName(
-                "nodomain.freeyourgadget.gadgetbridge",
-                "nodomain.freeyourgadget.gadgetbridge.externalevents.GenericWeatherReceiver"
-            )
-            putExtra("WeatherJson", rootWeatherJson.toString())
-            addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
-        }
-
-        context.sendBroadcast(intent)
-
-
+        context.packageManager
+            .queryBroadcastReceivers(Intent("nodomain.freeyourgadget.gadgetbridge.ACTION_GENERIC_WEATHER"), PackageManager.GET_RESOLVED_FILTER)
+            .forEach {
+                context.sendBroadcast(Intent("nodomain.freeyourgadget.gadgetbridge.ACTION_GENERIC_WEATHER").apply {
+                    setPackage(it.activityInfo.applicationInfo.packageName)
+                    putExtra("WeatherJson", rootWeatherJson.toString())
+                    addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
+                })
+            }
     } catch (e: Exception) {
     }
 }


### PR DESCRIPTION
Fixes #145

Previously, weather data was only broadcast to the hardcoded packages `nodomain.freeyourgadget.gadgetbridge` and `nodomain.freeyourgadget.gadgetbridge.nightly`. This PR instead queries the system for all apps that declare a receiver for the `nodomain.freeyourgadget.gadgetbridge.ACTION_GENERIC_WEATHER` intent and broadcasts the weather data to each one found.

Inspired by [Breezy Weather](https://github.com/breezy-weather/breezy-weather)'s Gadgetbridge implementation.