### PR TITLE
Add MetService NZ standalone alerts source

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/di/network/ApiModule.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/di/network/ApiModule.kt
@@ -3,6 +3,7 @@ package com.pranshulgg.weather_master_app.core.di.network
 import com.pranshulgg.weather_master_app.core.network.github.GithubApi
 import com.pranshulgg.weather_master_app.core.network.sources.address.nominatim.NominatimApi
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.fpas.FpasApi
+import com.pranshulgg.weather_master_app.core.network.sources.alerts.metservicenz.MetserviceNzApi
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.weatherapi.AlertsWeatherApi
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.wmosevereweather.WmoSevereWeatherApi
 import com.pranshulgg.weather_master_app.core.network.sources.search.accu.AccuSearchApi
@@ -136,6 +137,10 @@ object ApiModule {
     @Provides
     @Singleton
     fun provideFpasAlertsApi(): FpasApi = FpasApi.create()
+
+    @Provides
+    @Singleton
+    fun provideMetserviceNzAlertsApi(): MetserviceNzApi = MetserviceNzApi.create()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/alerts/AlertsRepositoryModule.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/di/weather/alerts/AlertsRepositoryModule.kt
@@ -2,6 +2,8 @@ package com.pranshulgg.weather_master_app.core.di.weather.alerts
 
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.fpas.FpasApi
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.fpas.FpasRepository
+import com.pranshulgg.weather_master_app.core.network.sources.alerts.metservicenz.MetserviceNzApi
+import com.pranshulgg.weather_master_app.core.network.sources.alerts.metservicenz.MetserviceNzRepository
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.weatherapi.AlertsWeatherApi
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.weatherapi.AlertsWeatherApiRepository
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.wmosevereweather.WmoSevereWeatherApi
@@ -34,6 +36,14 @@ object AlertsRepositoryModule {
         dao: AlertsDao,
         locationsDao: LocationsDao
     ): FpasRepository = FpasRepository(api, dao, locationsDao)
+
+    @Provides
+    @Singleton
+    fun provideMetserviceNzAlertsRepository(
+        api: MetserviceNzApi,
+        dao: AlertsDao,
+        locationsDao: LocationsDao
+    ): MetserviceNzRepository = MetserviceNzRepository(api, dao, locationsDao)
 
 
     @Provides

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/model/sources/Source.kt
@@ -198,6 +198,13 @@ enum class Source(
         displayLink = "https://openweathermap.org/",
         capabilities = setOf(Capability.WEATHER, Capability.AIR_QUALITY),
         requiresUserApiKey = true
+    ),
+    METSERVICE_NZ(
+        displayName = "MetService NZ",
+        fullName = "Meteorological Service of New Zealand",
+        displayLink = "https://alerts.metservice.com/",
+        countryNameRes = R.string.country_new_zealand,
+        capabilities = setOf(Capability.ALERTS)
     );
 
     // Sources that provide snow/rain as precipitation
@@ -238,6 +245,7 @@ private val sourcesByCountry = buildMap {
     put("TW", listOf(Source.CWA))
     put("JP", listOf(Source.JMA))
     put("BR", listOf(Source.INMET))
+    put("NZ", listOf(Source.METSERVICE_NZ))
 
 }
 

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/metservicenz/MetserviceNzApi.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/metservicenz/MetserviceNzApi.kt
@@ -1,0 +1,39 @@
+package com.pranshulgg.weather_master_app.core.network.sources.alerts.metservicenz
+
+import okhttp3.OkHttpClient
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Url
+import java.util.concurrent.TimeUnit
+
+
+interface MetserviceNzApi {
+
+    @GET("cap/rss")
+    suspend fun fetchAlertsFeed(): Response<ResponseBody>
+
+    @GET
+    suspend fun fetchAlertXml(@Url url: String): Response<ResponseBody>
+
+    companion object {
+        const val BASE_URL = "https://alerts.metservice.com/"
+
+        fun create(): MetserviceNzApi {
+
+            val client = OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build()
+
+            return Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(MetserviceNzApi::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/metservicenz/MetserviceNzRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/metservicenz/MetserviceNzRepository.kt
@@ -1,0 +1,210 @@
+package com.pranshulgg.weather_master_app.core.network.sources.alerts.metservicenz
+
+import android.util.Xml
+import com.pranshulgg.weather_master_app.core.model.domain.AppException
+import com.pranshulgg.weather_master_app.core.model.domain.location.Location
+import com.pranshulgg.weather_master_app.core.model.sources.Source
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResult
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertResultType
+import com.pranshulgg.weather_master_app.core.network.sources.alerts.metservicenz.model.MetserviceNzCapAlert
+import com.pranshulgg.weather_master_app.core.utils.weather.cache.shouldReturnAlertsCache
+import com.pranshulgg.weather_master_app.data.local.dao.alerts.AlertsDao
+import com.pranshulgg.weather_master_app.data.local.dao.location.LocationsDao
+import com.pranshulgg.weather_master_app.data.local.mapper.alerts.sources.metservicenz.metserviceNzAlertsMapper
+import com.pranshulgg.weather_master_app.data.local.mapper.alerts.toDomain
+import com.pranshulgg.weather_master_app.data.local.mapper.alerts.toEntity
+import com.pranshulgg.weather_master_app.data.repository.data.AlertRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.xmlpull.v1.XmlPullParser
+import java.io.InputStream
+import javax.inject.Inject
+
+
+class MetserviceNzRepository @Inject constructor(
+    private val api: MetserviceNzApi,
+    private val dao: AlertsDao,
+    private val locationsDao: LocationsDao
+) : AlertRepository {
+
+    override val alertSource = Source.METSERVICE_NZ
+
+    override suspend fun getAlerts(
+        location: Location,
+        isManualRefresh: Boolean,
+        isForceRefresh: Boolean
+    ): AlertResult = withContext(Dispatchers.IO) {
+
+        val cache = dao.getAlertsForLocation(location.id)
+        val shouldReturnCache = shouldReturnAlertsCache(
+            cache,
+            isManualRefresh,
+            isForceRefresh,
+            location.alertsLastFetchedAt
+        )
+
+        when (shouldReturnCache) {
+            AlertResultType.RETURN_CACHE -> return@withContext AlertResult.Success(cache.map { it!!.toDomain() })
+            else -> {}
+        }
+
+        return@withContext try {
+
+            val feedResponse = api.fetchAlertsFeed()
+            val feedBody = feedResponse.body()
+                ?: return@withContext AlertResult.Error(
+                    exception = AppException.Unknown(),
+                    cacheAlerts = cache.map { it!!.toDomain() })
+
+            val alertLinks = feedBody.byteStream().use { parseCapFeedLinks(it) }
+
+            // MetService's feed has no server-side geo filter (unlike NWS/FPAS), so
+            // every active alert nationwide is fetched and matched client-side against
+            // the location's point using the polygon(s) each CAP alert carries.
+            val alerts = alertLinks.mapNotNull { link ->
+                val responseAlert = api.fetchAlertXml(link)
+
+                if (responseAlert.isSuccessful) {
+                    responseAlert.body()?.byteStream()?.use { stream ->
+                        parseAlertXmlBody(stream)
+                    }
+                } else {
+                    null
+                }
+            }.filter { alert ->
+                alert.polygons.any { polygon ->
+                    pointInPolygon(location.latitude, location.longitude, polygon)
+                }
+            }
+
+            val domain = metserviceNzAlertsMapper(alerts, location.id)
+
+            dao.insertAlerts(
+                domain.map { it.toEntity(location.id) },
+                location.id
+            )
+
+            locationsDao.updateAlertsLastFetchedAt(location.id, System.currentTimeMillis())
+
+            AlertResult.Success(domain)
+
+        } catch (e: Exception) {
+            AlertResult.Error(exception = e, cacheAlerts = cache.map { it!!.toDomain() })
+        }
+    }
+}
+
+private fun parseCapFeedLinks(inputStream: InputStream): List<String> {
+    val parser = Xml.newPullParser()
+    parser.setInput(inputStream, null)
+
+    val links = mutableListOf<String>()
+    var type = parser.eventType
+    var insideItem = false
+
+    while (type != XmlPullParser.END_DOCUMENT) {
+        when (type) {
+            XmlPullParser.START_TAG -> {
+                when (parser.name) {
+                    "item" -> insideItem = true
+                    "link" -> if (insideItem) links.add(parser.nextText().trim())
+                }
+            }
+
+            XmlPullParser.END_TAG -> {
+                if (parser.name == "item") insideItem = false
+            }
+        }
+        type = parser.next()
+    }
+    return links
+}
+
+private fun parseAlertXmlBody(stream: InputStream): MetserviceNzCapAlert {
+    val parser = Xml.newPullParser()
+    parser.setInput(stream, null)
+
+    var type = parser.eventType
+
+    var event: String? = null
+    var severity: String? = null
+    var onset: String? = null
+    var expires: String? = null
+    var senderName: String? = null
+    var description: String? = null
+    var headline: String? = null
+    var inInfo = false
+    var infoCaptured = false
+
+    val polygons = mutableListOf<List<Pair<Double, Double>>>()
+
+    while (type != XmlPullParser.END_DOCUMENT) {
+        when (type) {
+            XmlPullParser.START_TAG -> {
+                when (parser.name) {
+                    // a CAP alert can carry multiple <info> blocks (e.g. per language);
+                    // MetService's feed is English-only, so we just take the first one
+                    "info" -> inInfo = !infoCaptured
+
+                    "event" -> if (inInfo) event = parser.nextText()
+                    "severity" -> if (inInfo) severity = parser.nextText()
+                    "onset" -> if (inInfo) onset = parser.nextText()
+                    "expires" -> if (inInfo) expires = parser.nextText()
+                    "senderName" -> if (inInfo) senderName = parser.nextText()
+                    "description" -> if (inInfo) description = parser.nextText()
+                    "headline" -> if (inInfo) headline = parser.nextText()
+                    "polygon" -> if (inInfo) polygons.add(parsePolygon(parser.nextText()))
+                }
+            }
+
+            XmlPullParser.END_TAG -> {
+                if (parser.name == "info" && inInfo) {
+                    infoCaptured = true
+                    inInfo = false
+                }
+            }
+        }
+        type = parser.next()
+    }
+
+    return MetserviceNzCapAlert(
+        event = event,
+        severity = severity,
+        onset = onset,
+        expires = expires,
+        senderName = senderName,
+        headline = headline,
+        description = description,
+        polygons = polygons
+    )
+}
+
+// CAP polygon format: whitespace-separated "lat,lon" pairs forming a closed ring.
+private fun parsePolygon(raw: String): List<Pair<Double, Double>> {
+    return raw.trim().split(Regex("\\s+")).mapNotNull { pair ->
+        val parts = pair.split(",")
+        if (parts.size != 2) return@mapNotNull null
+        val lat = parts[0].toDoubleOrNull() ?: return@mapNotNull null
+        val lon = parts[1].toDoubleOrNull() ?: return@mapNotNull null
+        lat to lon
+    }
+}
+
+// Standard ray-casting point-in-polygon test.
+private fun pointInPolygon(lat: Double, lon: Double, polygon: List<Pair<Double, Double>>): Boolean {
+    if (polygon.size < 3) return false
+
+    var inside = false
+    var j = polygon.size - 1
+    for (i in polygon.indices) {
+        val (latI, lonI) = polygon[i]
+        val (latJ, lonJ) = polygon[j]
+        if ((lonI > lon) != (lonJ > lon) &&
+            lat < (latJ - latI) * (lon - lonI) / (lonJ - lonI) + latI
+        ) {
+            inside = !inside
+        }
+        j = i
+    }
+    return inside
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/metservicenz/MetserviceNzRepository.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/metservicenz/MetserviceNzRepository.kt
@@ -21,6 +21,9 @@ import java.io.InputStream
 import javax.inject.Inject
 
 
+/**
+ * MetService NZ standalone CAP alerts integration implemented by https://github.com/reveler-hub
+ */
 class MetserviceNzRepository @Inject constructor(
     private val api: MetserviceNzApi,
     private val dao: AlertsDao,

--- a/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/metservicenz/model/MetserviceNzCapAlert.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/core/network/sources/alerts/metservicenz/model/MetserviceNzCapAlert.kt
@@ -1,0 +1,12 @@
+package com.pranshulgg.weather_master_app.core.network.sources.alerts.metservicenz.model
+
+data class MetserviceNzCapAlert(
+    val event: String?,
+    val severity: String?,
+    val onset: String?,
+    val expires: String?,
+    val senderName: String?,
+    val headline: String?,
+    val description: String?,
+    val polygons: List<List<Pair<Double, Double>>>
+)

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/alerts/sources/metservicenz/MetserviceNzAlertsMapper.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/local/mapper/alerts/sources/metservicenz/MetserviceNzAlertsMapper.kt
@@ -1,0 +1,37 @@
+package com.pranshulgg.weather_master_app.data.local.mapper.alerts.sources.metservicenz
+
+import com.pranshulgg.weather_master_app.core.model.domain.alerts.Alert
+import com.pranshulgg.weather_master_app.core.model.weather.alerts.AlertSeverity
+import com.pranshulgg.weather_master_app.core.network.sources.alerts.metservicenz.model.MetserviceNzCapAlert
+import com.pranshulgg.weather_master_app.core.utils.extensions.DateTimeExtensions.iso8601TimestampToMilliseconds
+
+
+fun metserviceNzAlertsMapper(
+    alerts: List<MetserviceNzCapAlert>,
+    locationId: String
+): List<Alert> {
+
+    return alerts.map { capAlert ->
+
+        Alert(
+            locationId = locationId,
+            event = capAlert.event ?: capAlert.headline ?: "",
+            severity = getSeverity(capAlert.severity),
+            effective = capAlert.onset?.iso8601TimestampToMilliseconds(),
+            expires = capAlert.expires?.iso8601TimestampToMilliseconds(),
+            description = capAlert.description ?: "",
+            lastUpdatedInMilli = System.currentTimeMillis(),
+            source = capAlert.senderName ?: "MetService"
+        )
+    }
+}
+
+private fun getSeverity(value: String?): AlertSeverity {
+    return when (value) {
+        "Extreme" -> AlertSeverity.CRITICAL
+        "Severe" -> AlertSeverity.HIGH
+        "Moderate" -> AlertSeverity.MODERATE
+        "Minor" -> AlertSeverity.LOW
+        else -> AlertSeverity.UNKNOWN
+    }
+}

--- a/app/src/main/java/com/pranshulgg/weather_master_app/data/provider/SourceRepositoryProvider.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/data/provider/SourceRepositoryProvider.kt
@@ -2,6 +2,7 @@ package com.pranshulgg.weather_master_app.data.provider
 
 import com.pranshulgg.weather_master_app.core.model.sources.Source
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.fpas.FpasRepository
+import com.pranshulgg.weather_master_app.core.network.sources.alerts.metservicenz.MetserviceNzRepository
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.weatherapi.AlertsWeatherApiRepository
 import com.pranshulgg.weather_master_app.core.network.sources.alerts.wmosevereweather.WmoSevereWeatherRepository
 import com.pranshulgg.weather_master_app.core.network.sources.weather.accu.AccuRepository
@@ -59,6 +60,7 @@ class SourceRepositoryProvider @Inject constructor(
     private val alertsWeatherApiRepository: AlertsWeatherApiRepository,
     private val wmoSevereWeatherRepository: WmoSevereWeatherRepository,
     private val fpasRepository: FpasRepository,
+    private val metserviceNzRepository: MetserviceNzRepository,
 
     ) {
 
@@ -87,6 +89,7 @@ class SourceRepositoryProvider @Inject constructor(
         alertsWeatherApiRepository,
         wmoSevereWeatherRepository,
         fpasRepository,
+        metserviceNzRepository,
         openWeatherRepository
     )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,6 +448,7 @@
     <string name="country_spain">Spain</string>
     <string name="country_taiwan">Taiwan</string>
     <string name="country_brazil">Brazil</string>
+    <string name="country_new_zealand">New Zealand</string>
 
     <string name="settings_date_format">Date format</string>
     <string name="widget_settings_display_hourly_secondary">Displays hourly instead of daily forecast</string>


### PR DESCRIPTION
Closes #1132.

New Zealand's national met service (MetService) publishes a public, keyless CAP (Common Alerting Protocol) 1.2 feed for current weather watches/warnings/advisories at `alerts.metservice.com/cap/rss` — same standard the app's existing NWS alerts already use. This is a standalone alerts source (like FPAS/WMO Severe Weather), not paired to a specific weather source.

**How it works:**
- Fetches the RSS feed, which lists links to individual CAP XML alerts (no server-side geo filter, unlike NWS/FPAS).
- Each CAP alert carries one or more `<area><polygon>` geometries. Since there's no way to query by point, every active alert nationwide is fetched and matched against the location's coordinates with a point-in-polygon test client-side.
- Standard CAP fields map directly onto the app's `Alert` model: `event`, `severity` (Extreme/Severe/Moderate/Minor — same vocabulary as NWS), `onset`/`expires`, `headline`, `description`, `senderName`.

New Zealand currently has no country-specific recommended source, so NZ users only saw the generic worldwide alert list — this closes that gap.

**Verification (live, on-device):**
- Confirmed the point-in-polygon logic against real feed data: random-sampled 20,000 points across an active alert's bounding box, correctly identified ~1.75% as inside (matches the alert being a narrow road-corridor polygon, not a regional blob).
- Added a real NZ location (Wellington), confirmed MetService NZ appears under Recommended sources and is selectable.
- Confirmed a live fetch: RSS → per-alert CAP XML → point-in-polygon filter → cached correctly, with `alertsLastFetchedAt` recorded and no crash, for a location with zero matching alerts (correct empty result, not a false negative — verified by testing towns known to fall inside currently-active alert polygons, e.g. Invercargill/Lake Tekapo under an active Strong Wind Watch).

Built and tested with Claude Code assistance, per this repo's AI-disclosure guidelines.
