### PR TITLE
Fix alerts-only country-recommended sources leaking into weather picker

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/search/SearchScreenViewModel.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/search/SearchScreenViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.pranshulgg.weather_master_app.R
 import com.pranshulgg.weather_master_app.core.model.sources.Capability
 import com.pranshulgg.weather_master_app.core.model.sources.SearchSource
+import com.pranshulgg.weather_master_app.core.model.sources.getSourcesForCountry
 import com.pranshulgg.weather_master_app.core.model.domain.location.Location
 import com.pranshulgg.weather_master_app.core.model.domain.toAppException
 import com.pranshulgg.weather_master_app.core.model.domain.toMessageRes
@@ -84,7 +85,9 @@ class SearchScreenViewModel @Inject constructor(
                 val alertSource = if (Capability.ALERTS in weatherSource.capabilities) {
                     weatherSource
                 } else {
-                    resolved.alertSource
+                    getSourcesForCountry(resolved.countryCode?.uppercase())
+                        .firstOrNull { Capability.ALERTS in it.capabilities }
+                        ?: resolved.alertSource
                 }
                 locationsRepo.saveLocation(resolved.copy(source = weatherSource, alertSource = alertSource))
                 onBack()

--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/ui/SharedBottomSheets.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/shared/ui/SharedBottomSheets.kt
@@ -55,6 +55,7 @@ object SharedBottomSheet {
     ) {
         if (show) {
             val recommendedSources = getSourcesForCountry(countryCode?.uppercase())
+                .filter { Capability.WEATHER in it.capabilities }
             val globalSources = getSourcesGlobal().filter { Capability.WEATHER in it.capabilities }
 
             val isApiKeyAvailable: (Source) -> Boolean = { source ->


### PR DESCRIPTION
Found these two while testing the MetService NZ alerts source PR#1133 — not related to that source specifically, just the first time a country's recommended source happened to be alerts-only, which exposed both.

**1. Weather source picker didn't filter recommended sources by capability**

`SharedBottomSheet.WeatherSourcesForLocationSheet`'s `recommendedSources` list (`SharedBottomSheets.kt`) wasn't filtered by `Capability.WEATHER`, unlike its `globalSources` list which correctly is. Every country's recommended source has so far also been a real weather source (NWS, DWD, JMA, etc.), so this never mattered — but an alerts-only recommended source would show up, and even get auto-selected by default, in the *weather* source picker, where it doesn't belong. It wouldn't crash (`SourceRepositoryProvider.getWeatherRepository()` falls back to Open-Meteo when there's no matching `WeatherRepository`), but it would mislabel the location's weather source while actually pulling Open-Meteo data underneath.

Fix: filter `recommendedSources` by `Capability.WEATHER`, matching how the alert/air-quality sheets in `EditLocationBottomSheet.kt` already do it.

**2. New-location alert source only paired with self-paired weather sources**

`SearchScreenViewModel.saveLocation()` only auto-sets a new location's `alertSource` to match the picked `weatherSource` when that weather source itself has `Capability.ALERTS` (e.g. picking AccuWeather or JMA auto-pairs their own alerts). It never checked whether the country has its *own* recommended alerts-only source, so a country whose only recommended source is alerts-only (again — first case is NZ/MetService) would never get it auto-selected.

Fix: fall back to the country's recommended alerts-capable source (`getSourcesForCountry(...).firstOrNull { Capability.ALERTS in it.capabilities }`) before falling back to whatever the raw location already had.

**Verification (live, on-device):** added fresh NZ locations before and after each fix — confirmed the weather picker no longer offers MetService NZ, and confirmed a new location (Dunedin) correctly saves with `source=OPEN_METEO` / `alertSource=METSERVICE_NZ`.

Found and fixed with Claude Code assistance, per this repo's AI-disclosure guidelines.
