### PR TITLE
Fix unrounded pressure values on hourly detail card

### DIFF
--- a/app/src/main/java/com/pranshulgg/weather_master_app/feature/blocks/screens/pressure/components/PressureHourlyCard.kt
+++ b/app/src/main/java/com/pranshulgg/weather_master_app/feature/blocks/screens/pressure/components/PressureHourlyCard.kt
@@ -164,7 +164,11 @@ fun PressureHourlyCard(
                         }
                         Gap(5.dp)
                         Text(
-                            formatter(item.pressureMsl).toString(),
+                            formatLocalizedNumber(
+                                locale = getCurrentAppLocale(),
+                                number = formatter(item.pressureMsl)!!,
+                                decimalPlaces = 1
+                            ),
                             color = MaterialTheme.colorScheme.primary,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold


### PR DESCRIPTION
Closes #1137.

`PressureHourlyCard.kt`'s hourly pressure detail card converted the value from hPa to the user's selected unit and called `.toString()` directly on the raw `Double`. For hPa this mostly looked fine since the source data is already close to one decimal place, but for inHg (`hPa * 0.02953`) the multiplication produces long floating-point tails, e.g. `29.912312...` instead of `29.91`.

The main pressure block (`PressureBlock.kt`) already formats with `formatLocalizedNumber(..., decimalPlaces = 1)`. This applies the same formatting to the hourly detail card so both places are consistent, in hPa and in every other unit.

Tested live on-device (real phone, not emulator): confirmed unrounded decimals in inHg on the hourly card before the fix, and rounded 1-decimal values after, for both hPa and inHg.

Built and tested with Claude Code assistance, per this repo's AI-disclosure guidelines.
